### PR TITLE
render-build.shの追加

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -1,0 +1,5 @@
+set -o errexit
+
+bundle install
+bundle exec rails assets:precompile
+bundle exec rails assets:clean


### PR DESCRIPTION
# 概要
issue#4.5
## 実装内容
- [x] render-build.shの作成
Render.comでデプロイ予定だったが、必要なファイルが抜けていたので作成
4はデプロイ完了後に閉じるため、issue#4.5として追加