### PR TITLE
#12 i18nの日本語化対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 ruby '3.2.3'
 
+gem 'rails-i18n', '~> 7.0.0'
+
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem 'rails', '~> 7.1.3', '>= 7.1.3.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,6 +204,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails-i18n (7.0.9)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.1.3.2)
       actionpack (= 7.1.3.2)
       activesupport (= 7.1.3.2)
@@ -292,6 +295,7 @@ DEPENDENCIES
   pry-byebug
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.2)
+  rails-i18n (~> 7.0.0)
   rubocop
   selenium-webdriver
   sprockets-rails

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,9 +2,9 @@
 <footer class="navbar bg-base-300">
   <div class="flex justify-between items-center w-full">
     <nav class="flex space-x-4">
-      <%= link_to "contact us", 'https://docs.google.com/forms/d/e/1FAIpQLSc_jJJPojl8KWO4qfvx7uIzvTkLzc5qfhx2PseONpIUF5_SLA/viewform?embedded=true', class: "btn btn-ghost hover:bg-base-100 focus:ring-4 focus:ring-gray-300 font-medium rounded-lg text-sm px-4 lg:px-5 py-2 lg:py-2.5 mr-2 focus:outline-none" %>
-      <%= link_to "privacy_policy", "privacy_policy", class: "btn btn-ghost hover:bg-base-100 focus:ring-4 focus:ring-gray-300 font-medium rounded-lg text-sm px-4 lg:px-5 py-2 lg:py-2.5 mr-2 focus:outline-none" %>
-      <%= link_to "terms_of_service", "terms_of_service", class: "btn btn-ghost hover:bg-base-100 focus:ring-4 focus:ring-gray-300 font-medium rounded-lg text-sm px-4 lg:px-5 py-2 lg:py-2.5 mr-2 focus:outline-none" %>
+      <%= link_to t('footer.terms'), "terms", class: "btn btn-ghost hover:bg-base-100 focus:ring-4 focus:ring-gray-300 font-medium rounded-lg text-sm px-4 lg:px-5 py-2 lg:py-2.5 mr-2 focus:outline-none" %>
+      <%= link_to t('footer.privacy'), "privacy", class: "btn btn-ghost hover:bg-base-100 focus:ring-4 focus:ring-gray-300 font-medium rounded-lg text-sm px-4 lg:px-5 py-2 lg:py-2.5 mr-2 focus:outline-none" %>
+      <%= link_to t('footer.contact'), 'https://docs.google.com/forms/d/e/1FAIpQLSc_jJJPojl8KWO4qfvx7uIzvTkLzc5qfhx2PseONpIUF5_SLA/viewform?embedded=true', class: "btn btn-ghost hover:bg-base-100 focus:ring-4 focus:ring-gray-300 font-medium rounded-lg text-sm px-4 lg:px-5 py-2 lg:py-2.5 mr-2 focus:outline-none" %>
     </nav>
     <aside class="text-sm text-right">
       <p>Copyright © 2024 - All rights reserved by ACME Industries Ltd</p>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -14,19 +14,19 @@
       </div>
       <ul tabindex="0" class="menu dropdown-content z-[1] p-2 shadow bg-base-300 rounded-box w-52 mt-4">
         <li>
-          <a href="#" data-turbo-method="delete" method="delete" class="btn btn-ghost hover:bg-base-100 focus:ring-4 focus:ring-gray-300 font-medium rounded-lg text-sm px-4 lg:px-5 py-2 lg:py-2.5 mr-2 dark:hover:bg-gray-700 focus:outline-none dark:focus:ring-gray-800">サインアップ</a>
+          <a href="#" data-turbo-method="delete" method="delete" class="btn btn-ghost hover:bg-base-100 focus:ring-4 focus:ring-gray-300 font-medium rounded-lg text-sm px-4 lg:px-5 py-2 lg:py-2.5 mr-2 dark:hover:bg-gray-700 focus:outline-none dark:focus:ring-gray-800"><%= t('header.signup') %></a>
         </li>
         <li>
-          <a href="#" data-turbo-method="delete" method="delete" class="btn btn-ghost hover:bg-base-100 focus:ring-4 focus:ring-gray-300 font-medium rounded-lg text-sm px-4 lg:px-5 py-2 lg:py-2.5 mr-2 dark:hover:bg-gray-700 focus:outline-none dark:focus:ring-gray-800">サインイン</a>
+          <a href="#" data-turbo-method="delete" method="delete" class="btn btn-ghost hover:bg-base-100 focus:ring-4 focus:ring-gray-300 font-medium rounded-lg text-sm px-4 lg:px-5 py-2 lg:py-2.5 mr-2 dark:hover:bg-gray-700 focus:outline-none dark:focus:ring-gray-800"><%= t('header.signin') %></a>
         </li>
         <li>
-          <a href="#" class="btn btn-ghost hover:bg-base-100 focus:ring-4 focus:ring-gray-300 font-medium rounded-lg text-sm px-4 lg:px-5 py-2 lg:py-2.5 mr-2 dark:hover:bg-gray-700 focus:outline-none dark:focus:ring-gray-800">プロフィール</a>
+          <a href="#" class="btn btn-ghost hover:bg-base-100 focus:ring-4 focus:ring-gray-300 font-medium rounded-lg text-sm px-4 lg:px-5 py-2 lg:py-2.5 mr-2 dark:hover:bg-gray-700 focus:outline-none dark:focus:ring-gray-800"><%= t('header.profile') %></a>
         </li>
         <li>
           <a href="#" class="btn btn-ghost hover:bg-base-100 focus:ring-4 focus:ring-gray-300 font-medium rounded-lg text-sm px-4 lg:px-5 py-2 lg:py-2.5 mr-2 dark:hover:bg-gray-700 focus:outline-none dark:focus:ring-gray-800">AI</a>
         </li>
         <li>
-          <a href="#" class="btn btn-ghost hover:bg-base-100 focus:ring-4 focus:ring-gray-300 font-medium rounded-lg text-sm px-4 lg:px-5 py-2 lg:py-2.5 mr-2 dark:hover:bg-gray-700 focus:outline-none dark:focus:ring-gray-800">お気に入り</a>
+          <a href="#" class="btn btn-ghost hover:bg-base-100 focus:ring-4 focus:ring-gray-300 font-medium rounded-lg text-sm px-4 lg:px-5 py-2 lg:py-2.5 mr-2 dark:hover:bg-gray-700 focus:outline-none dark:focus:ring-gray-800"><%= t('header.bookmark') %></a>
         </li>
       </ul>
     </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,6 @@
-require_relative "boot"
+require_relative 'boot'
 
-require "rails/all"
+require 'rails/all'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -11,10 +11,13 @@ module Wordpass
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.1
 
+    # Set the default locale to Japanese
+    config.i18n.default_locale = :ja
+
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
-    config.autoload_lib(ignore: %w(assets tasks))
+    config.autoload_lib(ignore: %w[assets tasks])
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,0 +1,11 @@
+ja:
+  activerecord:
+    models:
+      user: ユーザー
+    attributes:
+      user:
+        email: メールアドレス
+        last_name: 姓
+        first_name: 名
+        password: パスワード
+        password_confirmation: パスワード確認

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,0 +1,30 @@
+ja:
+  helpers:
+    submit:
+      create: 登録
+      submit: 保存
+      update: 更新
+    label:
+      email: メールアドレス
+      password: パスワード
+  user_sessions:
+    new:
+      title: ログイン
+      login: ログイン
+      to_register_page: 登録ページへ
+      password_forget: パスワードをお忘れの方はこちら
+  users:
+    new:
+      title: ユーザー登録
+      to_login_page: ログインページへ
+  header:
+    signup: サインアップ
+    signin: サインイン
+    signout: サインアウト
+    profile: プロフィール
+    bookmark: ブックマーク
+  footer:
+    about: このサイトについて
+    terms: 利用規約
+    privacy: プライバシーポリシー
+    contact: お問い合わせ


### PR DESCRIPTION
# 概要
i18nの日本語化対応
## 実装内容
- [x] Gemfileに追記
```
gem 'rails-i18n', '~> 7.0.0'
```
- [x] config/locales配下にja.ymlを作成、中身を記述
config/locales/views/ja.yml
config/locales/activerecord/ja.yml
- [x] ヘッダーやフッターの各箇所のコードの修正（画像はフッター）
<img width="1271" alt="スクリーンショット 2024-05-03 18 36 36" src="https://github.com/daichi3102/wordpass/assets/149915927/9c42ffc8-2a45-47d1-bed2-99c600496ff2">

- [x] config/application.rbに追記

```
config.i18n.default_locale = :ja
```

- [x] ビューファイルに日本語を使っていないこと

Notion
https://www.notion.so/12-i18n-66098a1a89634da9a6cfa85d753587b0

closes #12 