### PR TITLE
#14 サインイン前後のビュー作成

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,11 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
   <body class="flex flex-col min-h-screen">
-    <%= render 'shared/header' %>
+    <% if user_signed_in? %>
+      <%= render 'shared/header' %>
+    <% else %>
+      <%= render 'shared/before_signin_header' %>
+    <% end %>
     <div class="flex-grow">
       <p class="notice"><%= notice %></p>
       <p class="alert"><%= alert %></p>

--- a/app/views/shared/_before_signin_header.html.erb
+++ b/app/views/shared/_before_signin_header.html.erb
@@ -1,0 +1,28 @@
+<header class="w-full navbar bg-base-300">
+  <div class="flex justify-between items-center w-full">
+    <!-- logo on the left -->
+    <div class="flex-1 px-2 lg:flex-none">
+      <a href="<%= root_path %>" class="btn btn-ghost text-xl text-blue-500 font-bold">WORDPASS</a>
+    </div>
+
+    <!-- Hamburger menu icon with dropdown on the right -->
+    <div class="dropdown dropdown-end flex-none">
+      <div tabindex="0" role="button" class="btn btn-square btn-ghost">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="inline-block w-5 h-5 stroke-current">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+        </svg>
+      </div>
+      <ul tabindex="0" class="menu dropdown-content z-[1] p-2 shadow bg-base-300 rounded-box w-52 mt-4">
+        <li>
+          <%= link_to t('header.signup'), new_user_registration_path, class: "btn btn-ghost hover:bg-base-100 focus:ring-4 focus:ring-gray-300 font-medium rounded-lg text-sm px-4 lg:px-5 py-2 lg:py-2.5 mr-2 dark:hover:bg-gray-700 focus:outline-none dark:focus:ring-gray-800" %>
+        </li>
+        <li>
+          <%= link_to t('header.signin'), new_user_session_path, class: "btn btn-ghost hover:bg-base-100 focus:ring-4 focus:ring-gray-300 font-medium rounded-lg text-sm px-4 lg:px-5 py-2 lg:py-2.5 mr-2 dark:hover:bg-gray-700 focus:outline-none dark:focus:ring-gray-800" %>
+        </li>
+        <li>
+          <a href="#" class="btn btn-ghost hover:bg-base-100 focus:ring-4 focus:ring-gray-300 font-medium rounded-lg text-sm px-4 lg:px-5 py-2 lg:py-2.5 mr-2 dark:hover:bg-gray-700 focus:outline-none dark:focus:ring-gray-800">AI</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</header>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -7,18 +7,12 @@
 
     <!-- Hamburger menu icon with dropdown on the right -->
     <div class="dropdown dropdown-end flex-none">
-      <div tabindex="0" role="button" class="btn btn-square btn-ghost">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="inline-block w-5 h-5 stroke-current">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
-        </svg>
+      <div tabindex="0" role="button" class="btn btn-ghost btn-circle avatar">
+        <div class="w-10 rounded-full">
+          <img alt="Tailwind CSS Navbar component" src="https://img.daisyui.com/images/stock/photo-1534528741775-53994a69daeb.jpg" />
+        </div>
       </div>
       <ul tabindex="0" class="menu dropdown-content z-[1] p-2 shadow bg-base-300 rounded-box w-52 mt-4">
-        <li>
-          <%= link_to t('header.signup'), new_user_registration_path, class: "btn btn-ghost hover:bg-base-100 focus:ring-4 focus:ring-gray-300 font-medium rounded-lg text-sm px-4 lg:px-5 py-2 lg:py-2.5 mr-2 dark:hover:bg-gray-700 focus:outline-none dark:focus:ring-gray-800" %>
-        </li>
-        <li>
-          <%= link_to t('header.signin'), new_user_session_path, class: "btn btn-ghost hover:bg-base-100 focus:ring-4 focus:ring-gray-300 font-medium rounded-lg text-sm px-4 lg:px-5 py-2 lg:py-2.5 mr-2 dark:hover:bg-gray-700 focus:outline-none dark:focus:ring-gray-800" %>
-        </li>
         <li>
           <%= link_to t('header.signout'), destroy_user_session_path, method: :delete, data: { turbo_method: "delete" }, class: "btn btn-ghost hover:bg-base-100 focus:ring-4 focus:ring-gray-300 font-medium rounded-lg text-sm px-4 lg:px-5 py-2 lg:py-2.5 mr-2 dark:hover:bg-gray-700 focus:outline-none dark:focus:ring-gray-800" %>
         </li>


### PR DESCRIPTION
# 概要
サインイン前後のビュー作成
## 実装内容
- [ ] app/views/shared/_before_signin_header.html.erbの作成と記述
- [ ] サインイン前後でヘッダーが変更される
- [ ] サインイン前後でヘッダーのモーダルの内容が変わる

<img width="1467" alt="スクリーンショット 2024-05-05 14 13 10" src="https://github.com/daichi3102/wordpass/assets/149915927/285a61e7-823e-4295-b5e8-a10ee4552ed6">
<img width="1467" alt="スクリーンショット 2024-05-05 14 13 32" src="https://github.com/daichi3102/wordpass/assets/149915927/1b414a62-b6d4-4994-9680-9274a14d6645">

実装ログ [Notion](https://www.notion.so/14-2cf9b55b03cf46ab97b47ab0cd8fcc3c)

closes #14 