### PR TITLE
#15 フラッシュメッセージの修正

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,8 +16,22 @@
       <%= render 'shared/before_signin_header' %>
     <% end %>
     <div class="flex-grow">
-      <p class="notice"><%= notice %></p>
-      <p class="alert"><%= alert %></p>
+      <% if notice %>
+        <div role="alert" class="alert alert-success">
+          <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <span><%= notice %></span>
+        </div>
+      <% end %>
+      <% if alert %>
+        <div role="alert" class="alert alert-error">
+          <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <span><%= alert %></span>
+        </div>
+      <% end %>
       <%= yield %>
     </div>
     <%= render 'shared/footer' %>

--- a/app/views/users/shared/_error_messages.html.erb
+++ b/app/views/users/shared/_error_messages.html.erb
@@ -1,12 +1,11 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation" data-turbo-cache="false">
-    <h2>
+  <div id="error_explanation" class="max-w-lg mx-auto w-full bg-base-300 border border-red-400 text-red-700 px-4 py-3 rounded relative" role="alert" data-turbo-cache="false">
+    <h2 class="font-bold">
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,
-                 resource: devise_i18n_fix_model_name_case(resource.model_name.human, i18n_key: 'errors.messages.not_saved'))
-       %>
+                 resource: devise_i18n_fix_model_name_case(resource.model_name.human, i18n_key: 'errors.messages.not_saved'))%>
     </h2>
-    <ul>
+    <ul class="list-disc pl-5 mt-3">
       <% resource.errors.full_messages.each do |message| %>
         <li><%= message %></li>
       <% end %>


### PR DESCRIPTION
# 概要
フラッシュメッセージの修正
## 概要
- [x] フラッシュメッセージのデザインの変更
- [x] エラーメッセージのデザインの変更
<img width="1467" alt="スクリーンショット 2024-05-07 9 54 06" src="https://github.com/daichi3102/wordpass/assets/149915927/04bcb156-02ab-46ed-bbcf-f4484eada8b4">


実装ログ [Notion](https://www.notion.so/15-b211ce3b8104478da37a0e5046f52f5f)
closes #15 