### PR TITLE
#19 プロフィール、フラッシュメッセージ、i18n（issue#19 アバター登録機能）

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -5,9 +5,9 @@ class ProfilesController < ApplicationController
 
   def update
     if @user.update(user_params)
-      redirect_to profile_path, success: t('defaults.flash_message.updated', item: User.model_name.human)
+      redirect_to profile_path, notice: t('defaults.flash_message.updated', item: t('profiles.show.title'))
     else
-      flash.now['danger'] = t('defaults.flash_message.not_updated', item: User.model_name.human)
+      flash.now[:alert] = t('defaults.flash_message.not_updated', item: t('profiles.show.title'))
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,22 +16,7 @@
       <%= render 'shared/before_signin_header' %>
     <% end %>
     <div class="flex-grow">
-      <% if notice %>
-        <div role="alert" class="alert alert-success">
-          <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-          </svg>
-          <span><%= notice %></span>
-        </div>
-      <% end %>
-      <% if alert %>
-        <div role="alert" class="alert alert-error">
-          <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" />
-          </svg>
-          <span><%= alert %></span>
-        </div>
-      <% end %>
+      <%= render 'shared/flash_message' %>
       <%= yield %>
     </div>
     <%= render 'shared/footer' %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,8 +1,8 @@
 <div class="flex justify-center items-start min-h-screen pt-8">
-  <div class="card bg-base-100 shadow-xl w-auto max-w-4xl">
+  <div class="card bg-base-100 shadow-xl w-auto" style="width: 32%; max-width: 1280px;">
     <div class="card-body">
       <%= form_with model: @user, url: profile_path, local: true, class: "flex flex-col gap-4 p-4 w-full max-w-lg" do |f| %>
-        <h1 class="text-xl font-bold mb-4">Update Your Profile</h1>
+        <h1 class="text-xl font-bold mb-4"><%= t('profiles.edit.title') %></h1>
         <!-- Name Label -->
         <div class="chat chat-start flex justify-start">
           <div class="chat-bubble bg-gray-800 text-white p-4 rounded-lg max-w-md">
@@ -12,7 +12,7 @@
         <!-- Name Input -->
         <div class="chat chat-end flex justify-end">
           <div class="chat-bubble bg-blue-600 text-white p-4 rounded-lg max-w-md">
-            <%= f.text_field :name, class: "input w-full max-w-lg bg-blue-600 text-white", placeholder: @user.name %>
+            <%= f.text_field :name, class: "bg-blue-600 text-white", autofocus: true, placeholder: @user.name %>
           </div>
         </div>
         <!-- Email Address Label -->
@@ -24,16 +24,16 @@
         <!-- Email Address Input -->
         <div class="chat chat-end flex justify-end">
           <div class="chat-bubble bg-blue-600 text-white p-4 rounded-lg max-w-md">
-            <%= f.email_field :email, class: "input w-full max-w-lg bg-blue-600 text-white", placeholder: "Enter your email" %>
+            <%= f.email_field :email, class: "bg-blue-600 text-white", placeholder: "Enter your email" %>
           </div>
         </div>
         <!-- Avatar Label -->
         <div class="chat chat-start flex justify-start">
           <div class="chat-bubble bg-gray-800 text-white p-4 rounded-lg max-w-md">
-            <%= f.label :avatar, class: "form-label" %>
+            <%= f.label :avatar, t('helpers.label.avatar'), class: "form-label" %>
           </div>
         </div>
-        <!-- Avatar Input -->
+        <!-- Avatar -->
         <div class="chat chat-end flex justify-end">
           <div class="chat-bubble bg-blue-600 text-white p-4 rounded-lg max-w-md">
             <%= f.file_field :avatar, class: 'form-control mb-3', accept: 'image/*' %>
@@ -48,7 +48,7 @@
         </div>
         <!-- Submit Button -->
         <div class="chat chat-end flex justify-end">
-          <%= f.submit "Update Profile", class: "btn btn-primary mt-4" %>
+          <%= f.submit "Update", class: "btn btn-primary mt-4" %>
         </div>
       <% end %>
     </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,47 +1,49 @@
 <div class="flex justify-center items-start min-h-screen pt-8">
-  <div class="card bg-base-100 shadow-xl w-auto max-w-4xl">
+  <div class="card bg-base-100 shadow-xl w-auto" style="width: 32%; max-width: 1280px;">
     <div class="card-body">
-      <div class="flex flex-col gap-4 p-4 w-full max-w-lg">
-        <h1 class="text-xl font-bold mb-4">Your Profile</h1>
+      <%= form_with model: @user, url: profile_path, local: true, class: "flex flex-col gap-4 p-4 w-full max-w-lg" do |f| %>
+        <h1 class="text-xl font-bold mb-4"><%= t('profiles.show.title') %></h1>
         <!-- Name Label -->
         <div class="chat chat-start flex justify-start">
           <div class="chat-bubble bg-gray-800 text-white p-4 rounded-lg max-w-md">
-            <strong>name</strong>
+            <%= f.label :name, class: "form-label" %>
           </div>
         </div>
-        <!-- Name Input -->
+        <!-- Name -->
         <div class="chat chat-end flex justify-end">
           <div class="chat-bubble bg-blue-600 text-white p-4 rounded-lg max-w-md">
-          <%= current_user.name %>
+            <%= current_user.name %>
           </div>
         </div>
         <!-- Email Address Label -->
         <div class="chat chat-start flex justify-start">
           <div class="chat-bubble bg-gray-800 text-white p-4 rounded-lg max-w-md">
-            <strong>mail</strong> 
+            <%= f.label :email, class: "form-label" %>
           </div>
         </div>
-        <!-- Email Address Input -->
+        <!-- Email Address -->
         <div class="chat chat-end flex justify-end">
           <div class="chat-bubble bg-blue-600 text-white p-4 rounded-lg max-w-md">
             <%= current_user.email %>
           </div>
         </div>
+        <!-- Avatar Label -->
         <div class="chat chat-start flex justify-start">
           <div class="chat-bubble bg-gray-800 text-white p-4 rounded-lg max-w-md">
-            <strong>avatar</strong> 
+            <%= f.label :avatar, class: "form-label" %>
           </div>
         </div>
+        <!-- Avatar Image -->
         <div class="chat chat-end flex justify-end">
-          <div class="chat-bubble bg-blue-600 text-white p-4 rounded-lg max-w-md">
+          <div class="chat-bubble bg-blue-600 text-white p-4 rounded-lg w-full">
             <%= image_tag current_user.avatar_url, class: 'rounded-circle', size: '100x100' %>
           </div>
         </div>
         <!-- Submit Button -->
-        <div class="chat chat-end flex justify-end">
+        <div class="flex justify-end w-full">
           <%= link_to t('profile.edit'), edit_profile_path, class: "btn btn-primary mt-4" %>
         </div>
-      </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,0 +1,17 @@
+<% flash.each do |message_type, message| %>
+  <% if message_type.to_s == 'notice' %>
+    <div role="alert" class="alert alert-success">
+      <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+      <span><%= message %></span>
+    </div>
+  <% elsif message_type.to_s == 'alert' %>
+    <div role="alert" class="alert alert-error">
+      <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+      <span><%= message %></span>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -9,7 +9,7 @@
     <div class="dropdown dropdown-end flex-none">
       <div tabindex="0" role="button" class="btn btn-ghost btn-circle avatar">
         <div class="w-10 rounded-full">
-          <img alt="Tailwind CSS Navbar component" src="https://img.daisyui.com/images/stock/photo-1534528741775-53994a69daeb.jpg" />
+          <%= image_tag current_user.avatar_url %>
         </div>
       </div>
       <ul tabindex="0" class="menu dropdown-content z-[1] p-2 shadow bg-base-300 rounded-box w-52 mt-4">
@@ -17,7 +17,7 @@
           <%= link_to t('header.signout'), destroy_user_session_path, method: :delete, data: { turbo_method: "delete" }, class: "btn btn-ghost hover:bg-base-100 focus:ring-4 focus:ring-gray-300 font-medium rounded-lg text-sm px-4 lg:px-5 py-2 lg:py-2.5 mr-2 dark:hover:bg-gray-700 focus:outline-none dark:focus:ring-gray-800" %>
         </li>
         <li>
-          <a href="#" class="btn btn-ghost hover:bg-base-100 focus:ring-4 focus:ring-gray-300 font-medium rounded-lg text-sm px-4 lg:px-5 py-2 lg:py-2.5 mr-2 dark:hover:bg-gray-700 focus:outline-none dark:focus:ring-gray-800"><%= t('header.profile') %></a>
+          <%= link_to t('header.profile'), profile_path, class: "btn btn-ghost hover:bg-base-100 focus:ring-4 focus:ring-gray-300 font-medium rounded-lg text-sm px-4 lg:px-5 py-2 lg:py-2.5 mr-2 dark:hover:bg-gray-700 focus:outline-none dark:focus:ring-gray-800" %>
         </li>
         <li>
           <a href="#" class="btn btn-ghost hover:bg-base-100 focus:ring-4 focus:ring-gray-300 font-medium rounded-lg text-sm px-4 lg:px-5 py-2 lg:py-2.5 mr-2 dark:hover:bg-gray-700 focus:outline-none dark:focus:ring-gray-800"><%= t('header.ai') %></a>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -6,12 +6,12 @@
 
     <div class="field">
       <%= f.label :name %><br />
-      <%= f.text_field :name, autofocus: true %>
+      <%= f.text_field :name, autofocus: true, autocomplete: "name" %>
     </div>
 
     <div class="field">
       <%= f.label :email %><br />
-      <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+      <%= f.email_field :email, autocomplete: "email" %>
     </div>
 
     <div class="field">

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -5,7 +5,7 @@
 
     <div class="field">
       <%= f.label :name %><br />
-      <%= f.text_field :name, autofocus: true %>
+      <%= f.text_field :name, autofocus: true, autocomplete: "name" %>
     </div>
   
     <div class="field">

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -8,6 +8,24 @@ ja:
       name: 名前
       email: メールアドレス
       password: パスワード
+      avatar: アバター
+  defaults:
+    create: 作成
+    post: 投稿
+    edit: 編集
+    show: 詳細
+    delete: 削除
+    delete_confirm: 削除しますか？
+    password_reset: パスワードリセット
+    unspecified: 指定なし
+    flash_message:
+      created: "%{item}を作成しました"
+      not_created: "%{item}を作成出来ませんでした"
+      updated: "%{item}を更新しました"
+      not_updated: "%{item}を更新出来ませんでした"
+      deleted: "%{item}を削除しました"
+      require_login: ログインしてください
+      not_authorized: 権限がありません
   user_sessions:
     new:
       title: ログイン
@@ -30,3 +48,8 @@ ja:
     terms: 利用規約
     privacy: プライバシーポリシー
     contact: お問い合わせ
+  profiles:
+    show:
+      title: プロフィール
+    edit:
+      title: プロフィール編集


### PR DESCRIPTION
# 概要
プロフィール、フラッシュメッセージ、i18n
（アバター登録機能は実装済み）
## 実装内容
- [x] プロフィールページのレイアウトの調整
- [x] ヘッダーのアイコン画像の変更
- [x] ヘッダーのモーダルの変更
- [x] フラッシュメッセージファイルの作成
- [x] ja.ymlファイルの修正
- [x] サインアップ、サインイン、サインアウト時のフラッシュメッセージも共通のファイルを使うように変更
## 確認ポイント
- [x] ヘッダーのアイコンがサインインしているユーザーのアバターになっている
- [x] ヘッダーのモーダルからプロフィールページに画面遷移できる
- [x] プロフィール編集から、更新成功時に緑色のフラッシュメッセージが表示される
- [x] プロフィール編集から、更新失敗時に赤色のフラッシュメッセージが表示される
- [x] ユーザー認証時も、プロフィール編集時も、同じパーシャルファイルを使っていること

<img width="1455" alt="スクリーンショット 2024-05-09 12 50 16" src="https://github.com/daichi3102/wordpass/assets/149915927/d501e270-777a-4cd1-acc8-c737b64f748e">
<img width="1456" alt="スクリーンショット 2024-05-09 13 35 58" src="https://github.com/daichi3102/wordpass/assets/149915927/29f903ce-24b3-4bc7-a5ee-dd76c915c90f">

実装ログ [Notion](https://www.notion.so/19-8ad4c6d32c16481d8477471ae6ca0006)
closes #19 