### PR TITLE
#21 AIからの名言取得機能の追加

### DIFF
--- a/app/controllers/fetch_ais_controller.rb
+++ b/app/controllers/fetch_ais_controller.rb
@@ -1,0 +1,38 @@
+class FetchAisController < ApplicationController
+  def index
+  end
+
+  def show
+    @fetch_ai = FetchAi.find(params[:id])
+  end
+
+  def new
+  end
+
+  def edit
+  end
+
+  def create
+    @fetch_ai = FetchAi.new
+    @fetch_ai.user = current_user if user_signed_in? # ログインしていればユーザーを設定
+
+    prompt = <<~PROMPT
+      名言や格言と言われるものを、映画、書籍、漫画、アニメ等から１つ引用してください。
+      引用作品名と、著者もしくは登場人物名を記載してください。
+      引用情報のみで、対話型の返答は省き、日本語でお願いします。
+    PROMPT
+
+    begin
+      response = ChatgptService.call(prompt)
+      @fetch_ai.response = response
+      if @fetch_ai.save
+        redirect_to fetch_ai_path(@fetch_ai), notice: '名言を受け取りました'
+      else
+        redirect_to root_path, alert: '保存に失敗しました。' + @fetch_ai.errors.full_messages.to_sentence
+      end
+    rescue Net::ReadTimeout, StandardError => e
+      logger.error "Failed to call OpenAI: #{e.message}"
+      redirect_to root_path, alert: 'OpenAIサービスの呼び出しに失敗しました。'
+    end
+  end
+end

--- a/app/models/fetch_ai.rb
+++ b/app/models/fetch_ai.rb
@@ -1,0 +1,4 @@
+class FetchAi < ApplicationRecord
+  # optional: true を追加してユーザーの関連付けをオプショナルにする
+  belongs_to :user, optional: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,7 @@ class User < ApplicationRecord
   mount_uploader :avatar, AvatarUploader
 
   has_many :sns_credentials, dependent: :destroy
+  has_many :fetch_ais, dependent: :destroy
 
   validates :name, presence: true
   validates :email, uniqueness: true

--- a/app/service/chatgpt_service.rb
+++ b/app/service/chatgpt_service.rb
@@ -32,7 +32,7 @@ class ChatgptService
   end
 
   class << self
-    def call(message, model = 'gpt-4.0-turbo')
+    def call(message, model = 'gpt-3.5-turbo')
       new(message, model).call
     end
   end

--- a/app/views/fetch_ais/edit.html.erb
+++ b/app/views/fetch_ais/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>FetchAis#edit</h1>
+<p>Find me in app/views/fetch_ais/edit.html.erb</p>

--- a/app/views/fetch_ais/index.html.erb
+++ b/app/views/fetch_ais/index.html.erb
@@ -1,0 +1,2 @@
+<h1>FetchAis#index</h1>
+<p>Find me in app/views/fetch_ais/index.html.erb</p>

--- a/app/views/fetch_ais/new.html.erb
+++ b/app/views/fetch_ais/new.html.erb
@@ -1,0 +1,2 @@
+<h1>FetchAis#new</h1>
+<p>Find me in app/views/fetch_ais/new.html.erb</p>

--- a/app/views/fetch_ais/show.html.erb
+++ b/app/views/fetch_ais/show.html.erb
@@ -1,0 +1,3 @@
+<!-- app/views/fetch_ais/show.html.erb -->
+<h1>Generated Quote</h1>
+<p><%= @fetch_ai.response %></p>

--- a/app/views/tops/index.html.erb
+++ b/app/views/tops/index.html.erb
@@ -2,10 +2,5 @@
     Hello world!
 </h1>
 <div class="flex justify-center mt-4">
-    <button class="bg-gray-900 hover:bg-gray-800 text-white rounded px-4 py-2">
-        tailwind
-    </button>
-    <button class="btn">
-        daisyUI
-    </button>
+  <%= button_to '名言を取得', fetch_ais_path, method: :post %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
     omniauth_callbacks: 'users/omniauth_callbacks'
   }
   resource :profile, only: %i[show edit update]
+  resources :fetch_ais
   root to: 'tops#index'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   get '/terms', to: 'tops#terms'

--- a/db/migrate/20240510090317_create_fetch_ais.rb
+++ b/db/migrate/20240510090317_create_fetch_ais.rb
@@ -1,0 +1,14 @@
+class CreateFetchAis < ActiveRecord::Migration[7.1]
+  def change
+    create_table :fetch_ais do |t|
+      t.string :mood
+      t.string :schedule
+      t.string :how
+      t.string :popularity
+      t.string :quote_type
+      t.text :response
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240511053430_add_user_id_to_fetch_ais.rb
+++ b/db/migrate/20240511053430_add_user_id_to_fetch_ais.rb
@@ -1,0 +1,5 @@
+class AddUserIdToFetchAis < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :fetch_ais, :user, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_07_082817) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_11_053430) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "fetch_ais", force: :cascade do |t|
+    t.string "mood"
+    t.string "schedule"
+    t.string "how"
+    t.string "popularity"
+    t.string "quote_type"
+    t.text "response"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_fetch_ais_on_user_id"
+  end
 
   create_table "sns_credentials", force: :cascade do |t|
     t.string "provider"
@@ -37,5 +50,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_07_082817) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "fetch_ais", "users"
   add_foreign_key "sns_credentials", "users"
 end

--- a/spec/controllers/fetch_ais_controller_spec.rb
+++ b/spec/controllers/fetch_ais_controller_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe FetchAisController, type: :controller do
+
+  describe "GET #index" do
+    it "returns http success" do
+      get :index
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET #show" do
+    it "returns http success" do
+      get :show
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET #new" do
+    it "returns http success" do
+      get :new
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET #edit" do
+    it "returns http success" do
+      get :edit
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/factories/fetch_ais.rb
+++ b/spec/factories/fetch_ais.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :fetch_ai do
+    mood { "MyString" }
+    schedule { "MyString" }
+    how { "MyString" }
+    popularity { "MyString" }
+    quote_type { "MyString" }
+    response { "MyText" }
+  end
+end

--- a/spec/models/fetch_ai_spec.rb
+++ b/spec/models/fetch_ai_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe FetchAi, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# 概要
AIからの名言取得機能の追加
## 実装内容
- [x] FetchAiモデルの作成
- [x] FetchAisコントローラの作成
- [x] FetchAisビューの作成
- [x] ルーティングの記述
- [x] Userモデルとの関連付け
- [x] null: true,optional: trueの設定
## 確認ポイント
- [x] サインイン、サインアウト時にも名言の取得が可能
- [x] トップページから結果画面に遷移すること
<img width="951" alt="スクリーンショット 2024-05-11 16 28 36" src="https://github.com/daichi3102/wordpass/assets/149915927/7845fdd4-8cf3-4b2a-9ade-4f61270e5125">

実装ログ [Notion](https://www.notion.so/21-AI-1c2811f8928d4edb8e253b001a348088)
closes #21 