### PR TITLE
パーソナライズ機能の追加（２）

### DIFF
--- a/app/views/fetch_ais/index.html.erb
+++ b/app/views/fetch_ais/index.html.erb
@@ -1,2 +1,25 @@
-<h1>FetchAis#index</h1>
-<p>Find me in app/views/fetch_ais/index.html.erb</p>
+<% if user_signed_in? %>
+  <div class="flex justify-center items-center min-h-screen pt-8 flex-col"> <!-- flex-colを追加、items-startをitems-centerに変更 -->
+    <h1 class="text-xl font-bold mb-4 text-center"><%= t('fetch_ais.show.title') %></h1>
+    <% @fetch_ais.each do |fetch_ai| %>
+      <% if fetch_ai.response.present? %>
+        <div class="card bg-base-100 shadow-xl w-auto my-2 mx-auto" style="width: 100%; max-width: 640px;"> <!-- mx-autoでカードを中央に配置 -->
+          <div class="card-body">
+            <div class="chat chat-start flex justify-start">
+              <div class="chat-bubble bg-gray-800 text-white p-4 rounded-lg max-w-md">
+                <%= fetch_ai.response %>
+              </div>
+            </div>
+            <div class="chat chat-end flex justify-end"> <!-- justify-endで右に配置 -->
+              <div class="chat-bubble bg-blue-600 text-white p-4 rounded-lg max-w-md">
+                <%= button_to 'destroy', fetch_ai_path(fetch_ai), method: :delete, data: { confirm: '本当に削除しますか？' }, class: 'btn text-white mt-4', style: 'background-color: #1f2937;' %> <!-- bg-blue-600の色を保持 -->
+              </div>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+<% else %>
+  <p>サインインしてください。</p>
+<% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -20,7 +20,7 @@
           <%= link_to t('header.profile'), profile_path, class: "btn btn-ghost hover:bg-base-100 focus:ring-4 focus:ring-gray-300 font-medium rounded-lg text-sm px-4 lg:px-5 py-2 lg:py-2.5 mr-2 dark:hover:bg-gray-700 focus:outline-none dark:focus:ring-gray-800" %>
         </li>
         <li>
-          <%= link_to t('header.ai'), root_path, class: "btn btn-ghost hover:bg-base-100 focus:ring-4 focus:ring-gray-300 font-medium rounded-lg text-sm px-4 lg:px-5 py-2 lg:py-2.5 mr-2 dark:hover:bg-gray-700 focus:outline-none dark:focus:ring-gray-800" %>
+          <%= link_to t('header.ai_index'), fetch_ais_path, class: "btn btn-ghost hover:bg-base-100 focus:ring-4 focus:ring-gray-300 font-medium rounded-lg text-sm px-4 lg:px-5 py-2 lg:py-2.5 mr-2 dark:hover:bg-gray-700 focus:outline-none dark:focus:ring-gray-800" %>
         </li>
         <li>
           <a href="#" class="btn btn-ghost hover:bg-base-100 focus:ring-4 focus:ring-gray-300 font-medium rounded-lg text-sm px-4 lg:px-5 py-2 lg:py-2.5 mr-2 dark:hover:bg-gray-700 focus:outline-none dark:focus:ring-gray-800"><%= t('header.bookmark') %></a>

--- a/app/views/tops/index.html.erb
+++ b/app/views/tops/index.html.erb
@@ -18,42 +18,38 @@
         </div>
         <button class="btn btn-primary mt-4" onclick="my_modal_2.showModal()">パーソナライズして取得</button>
         <dialog id="my_modal_2" class="modal">
-          <div class="modal-box">
-            <h3 class="font-bold text-lg text-center">Hello!</h3>
-            <p class="py-4">下記のフォームを記入してください。</p>
-            <!-- フォームの追加 -->
-            <div class="container-sm mt-3">
-              <%= form_with model: @fetch_ai, local: true do |form| %>
-                <%= form.hidden_field :prompt_type, value: 'personalized' %>
-                <!-- フォームのフィールド -->
-                <div class="mb-3">
-                  <%= form.label :popularity, class: "form-label" %>
-                  <%= form.select :popularity, options_for_select(["メジャー", "マイナー", "メジャーでもマイナーでもない"], @fetch_ai.popularity), {}, {class: "form-control", id: "FetchAiPopularity"} %>
-                </div>
-                <!-- 続けて他のフィールドも同様に -->
-                <div class="mb-3">
-                  <%= form.label :quote_type, class: "form-label" %>
-                  <%= form.select :quote_type, options_for_select(["偉人", "有名人", "名著", "映画", "漫画", "アニメ"], @fetch_ai.quote_type), {}, {class: "form-control", id: "FetchAiQuoteType"} %>
-                </div>
-                <div class="mb-3">
-                  <%= form.label :mood, class: "form-label" %>
-                  <%= form.text_field :mood, {class: "form-control", id: "FetchAiMood"} %>
-                </div>
-                <div class="mb-3">
-                  <%= form.label :schedule, class: "form-label" %>
-                  <%= form.text_field :schedule, {class: "form-control", id: "FetchAiSchedule"} %>
-                </div>
-                <div class="mb-3">
-                  <%= form.label :how, class: "form-label" %>
-                  <%= form.text_field :how, {class: "form-control", id: "FetchAiHow"} %>
-                </div>
-                <!-- 他のフィールドも同様に追加 -->
-                <!-- サブミットボタンをCloseボタンに変更 -->
-                <div class="modal-action">
-                  <%= form.submit "Submit", class: "btn" %>
-                </div>
-              <% end %>
-            </div>
+          <div class="modal-box text-center">
+            <form method="dialog">
+              <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
+            </form>
+            <h3 class="font-bold text-lg">パーソナライズ</h3>
+            <p class="py-4">セレクトボックスから適当なものを選んでください</p>
+            <%= form_with model: @fetch_ai, local: true do |form| %>
+              <%= form.hidden_field :prompt_type, value: 'personalized' %>
+              <div class="mb-3 text-center">
+                <%= form.label :mood, class: "form-label block mb-2 text-sm font-bold" %>
+                <%= form.select :mood, options_for_select(["元気", "落ち気味", "普通", "悲しい", "イライラ"], @fetch_ai.mood), {}, {class: "select select-bordered w-full max-w-xs"} %>
+              </div>
+              <div class="mb-3 text-center">
+                <%= form.label :schedule, class: "form-label block mb-2 text-sm font-bold" %>
+                <%= form.select :schedule, options_for_select(["仕事", "学習", "健康の事", "家庭の事", "趣味", "自己に関わること"], @fetch_ai.schedule), {}, {class: "select select-bordered w-full max-w-xs"} %>
+              </div>
+              <div class="mb-3 text-center">
+                <%= form.label :how, class: "form-label block mb-2 text-sm font-bold" %>
+                <%= form.select :how, options_for_select(["心に刺さる名言", "心に寄り添う名言", "クスっと笑ってしまう名言", "厳しい名言"], @fetch_ai.how), {}, {class: "select select-bordered w-full max-w-xs"} %>
+              </div>
+              <div class="mb-3 text-center">
+                <%= form.label :popularity, class: "form-label block mb-2 text-sm font-bold" %>
+                <%= form.select :popularity, options_for_select(["メジャー", "マイナー", "メジャーでもマイナーでもないよう"], @fetch_ai.popularity), {}, {class: "select select-bordered w-full max-w-xs"} %>
+              </div>
+              <div class="mb-3 text-center">
+                <%= form.label :quote_type, class: "form-label block mb-2 text-sm font-bold" %>
+                <%= form.select :quote_type, options_for_select(["漫画", "映画", "アニメ", "書籍", "偉人", "有名人"], @fetch_ai.quote_type), {}, {class: "select select-bordered w-full max-w-xs"} %>
+              </div>
+              <div class="modal-action justify-center">
+                <%= form.submit "Submit", class: "btn btn-primary mt-4" %>
+              </div>
+            <% end %>
           </div>
         </dialog>
       <% else %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -44,6 +44,7 @@ ja:
     signin: サインイン
     signout: サインアウト
     profile: プロフィール
+    ai_index: AIからの一覧
     ai: AI
     bookmark: ブックマーク
   footer:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {
-    sessions: 'devise/sessions',
-    registrations: 'devise/registrations',
     omniauth_callbacks: 'users/omniauth_callbacks'
   }
   resource :profile, only: %i[show edit update]


### PR DESCRIPTION
# 概要
パーソナライズ機能の追加（２）
## 実装内容
- [x] FetchAisコントローラの修正
- [x] 取得した名言一覧ページの作成
- [x] ヘッダーにリンクを作成
## 確認ポイント
- [x] サインインしていない場合はパーソナライズ機能が使えない
- [x] サインインしていなくても元の機能は使える
- [x] ヘッダーから取得一覧ページが見れる
- [x] 取得一覧から削除が可能

<img width="1464" alt="スクリーンショット 2024-05-13 13 46 36" src="https://github.com/daichi3102/wordpass/assets/149915927/d7beab37-74c3-4f71-b639-5b37d9ac9eee">

実装ログ [Notion](https://www.notion.so/24-14a3d2f8247a4ee0b1457bf6792e81dd)
closes #24 