### PR TITLE
#26 Xへのシェア機能

### DIFF
--- a/app/controllers/fetch_ais_controller.rb
+++ b/app/controllers/fetch_ais_controller.rb
@@ -2,7 +2,7 @@ class FetchAisController < ApplicationController
   before_action :authenticate_user!, only: %i[index destroy]
 
   def index
-    @fetch_ais = current_user.fetch_ais
+    @fetch_ais = current_user.fetch_ais.order(created_at: :desc)
   end
 
   def show
@@ -18,7 +18,7 @@ class FetchAisController < ApplicationController
   def destroy
     @fetch_ai = current_user.fetch_ais.find(params[:id])
     @fetch_ai.destroy
-    redirect_to fetch_ais_path, notice: 'FetchAi was successfully destroyed.'
+    redirect_to fetch_ais_path, notice: t('defaults.flash_message.destroy_fetch_ai')
   end
 
   def create

--- a/app/views/fetch_ais/index.html.erb
+++ b/app/views/fetch_ais/index.html.erb
@@ -12,7 +12,13 @@
             </div>
             <div class="chat chat-end flex justify-end"> <!-- justify-endで右に配置 -->
               <div class="chat-bubble bg-blue-600 text-white p-4 rounded-lg max-w-md">
-                <%= button_to 'destroy', fetch_ai_path(fetch_ai), method: :delete, data: { confirm: '本当に削除しますか？' }, class: 'btn text-white mt-4', style: 'background-color: #1f2937;' %> <!-- bg-blue-600の色を保持 -->
+                <%= button_to 'destroy', fetch_ai_path(fetch_ai), method: :delete, data: { confirm: '本当に削除しますか？' }, class: 'btn text-white mt-4', style: 'background-color: #1f2937;' %>
+                <div class="mt-4">
+                  <%= link_to "https://twitter.com/share?url=https://wordpass-ldtw.onrender.com&text=今日は〇〇さんに励まされました！%0a%0a#{fetch_ai.response}", target: '_blank', class: "btn btn-info flex items-center justify-center gap-2" do %>
+                    <i class="fa-brands fa-x-twitter"></i>
+                    <span><%= t('fetch_ais.show.share') %></span>
+                  <% end %>
+                </div>
               </div>
             </div>
           </div>

--- a/app/views/fetch_ais/show.html.erb
+++ b/app/views/fetch_ais/show.html.erb
@@ -9,12 +9,17 @@
           <%= @fetch_ai.response %>
         </div>
       </div>
-        <!-- share -->
-        <div class="chat chat-end flex justify-end">
-          <div class="chat-bubble bg-blue-600 text-white p-4 rounded-lg max-w-md">
-            <%= link_to t('fetch_ais.show.share'), "#", class: "btn btn-primary mt-4" %>
+      <!-- share -->
+      <div class="chat chat-end flex justify-end">
+        <div class="chat-bubble bg-blue-600 text-white p-4 rounded-lg max-w-md">
+          <div class="mt-4">
+            <%= link_to "https://twitter.com/share?url=https://wordpass-ldtw.onrender.com&text=今日は〇〇さんに励まされました！%0a%0a#{@fetch_ai.response}", target: '_blank', class: "btn btn-info flex items-center justify-center gap-2" do %>
+              <i class="fa-brands fa-x-twitter"></i>
+              <span><%= t('fetch_ais.show.share') %></span>
+            <% end %>
           </div>
         </div>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,8 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+    <!-- Font Awesome CDN -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" rel="stylesheet">
   </head>
   <body class="flex flex-col min-h-screen">
     <% if user_signed_in? %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -28,6 +28,7 @@ ja:
       not_authorized: 権限がありません
       fetch_ai: AIから名言を受け取りました
       not_fetch_ai: AIから名言を受け取れませんでした
+      destroy_fetch_ai: AIから受け取った名言を削除しました
   user_sessions:
     new:
       title: ログイン
@@ -69,4 +70,4 @@ ja:
   fetch_ais:
     show:
       title: AIから受け取った名言一覧
-      share: Xでシェア
+      share: シェア


### PR DESCRIPTION
# 概要
Xへのシェア機能
## 実装内容
- [x] Xでのシェアボタンの追加
- [x] CDNでFontAwesomeの導入
## 確認ポイント
- [x] 名言を受け取った時にXでのシェアボタンがある
- [x] 名言一覧からもシェアボタンがある
- [x] シェア時に、決まった文言、名言の内容、リンク先が記載されている
<img width="905" alt="スクリーンショット 2024-05-13 17 55 25" src="https://github.com/daichi3102/wordpass/assets/149915927/d4feb24e-c529-4d58-ad96-635b61f13510">


<img width="910" alt="スクリーンショット 2024-05-13 18 28 56" src="https://github.com/daichi3102/wordpass/assets/149915927/e04bb051-79cc-4ef9-b1ad-8bee6e017bf2">

実装ログ [Notion](https://www.notion.so/26-X-59232f2fd30c47b293e6540ef9059f85)
closes #26 