### PR TITLE
#29 名言作成、削除＆編集機能の追加

### DIFF
--- a/app/controllers/fetch_ais_controller.rb
+++ b/app/controllers/fetch_ais_controller.rb
@@ -1,22 +1,33 @@
 class FetchAisController < ApplicationController
-  before_action :authenticate_user!, only: %i[index destroy]
+  before_action :authenticate_user!, only: %i[index new create edit update destroy]
+  before_action :set_fetch_ai, only: %i[show edit update destroy]
 
   def index
     @fetch_ais = current_user.fetch_ais.order(created_at: :desc)
+    @fetch_ai = FetchAi.new
   end
 
   def show
-    @fetch_ai = FetchAi.find(params[:id])
+    # @fetch_ai は before_action :set_fetch_ai によって設定されます
   end
 
   def new
+    @fetch_ai = FetchAi.new
   end
 
   def edit
+    # @fetch_ai は before_action :set_fetch_ai によって設定されます
+  end
+
+  def update
+    if @fetch_ai.update(fetch_ai_params)
+      redirect_to @fetch_ai, notice: 'FetchAi was successfully updated.'
+    else
+      render :edit
+    end
   end
 
   def destroy
-    @fetch_ai = current_user.fetch_ais.find(params[:id])
     @fetch_ai.destroy
     redirect_to fetch_ais_path, notice: t('defaults.flash_message.destroy_fetch_ai')
   end
@@ -40,14 +51,14 @@ class FetchAisController < ApplicationController
                    #{how}を、#{popularity}な#{quote_type}から1つ引用してください。
                    偉人や有名人の場合は、名前を記載してください。
                    書籍、映画、漫画、アニメの場合には引用作品名と、作者か登場人物名を記載してください。
-                   対話型の返答は省き、引用情報のみの日本語でお願いします。
+                   対話型の返答は省き、引用情報のみの日本語、名言を<quote></quote>で括り、その他の情報を<info></info>で括ってください。
                  PROMPT
                end
              else
                <<~PROMPT
                  名言や格言と言われるものを、映画、書籍、漫画、アニメ等から１つ引用してください。
                  引用作品名、作者、登場人物名を記載してください。
-                 引用情報のみで、対話型の返答は省き、日本語でお願いします。
+                 対話型の返答は省き、引用情報のみの日本語、名言を<quote></quote>で括り、その他の情報を<info></info>で括ってください。
                PROMPT
              end
 
@@ -81,5 +92,9 @@ class FetchAisController < ApplicationController
 
   def fetch_ai_params
     params.fetch(:fetch_ai, {}).permit(:prompt_type, :popularity, :quote_type, :mood, :schedule, :how)
+  end
+
+  def set_fetch_ai
+    @fetch_ai = FetchAi.find(params[:id])
   end
 end

--- a/app/controllers/first_parts_controller.rb
+++ b/app/controllers/first_parts_controller.rb
@@ -4,7 +4,11 @@ class FirstPartsController < ApplicationController
 
   # second_partsが存在しないmakeのみを取得
   def index
-    @first_parts = FirstPart.joins(:make).where(makes: { id: Make.left_outer_joins(:second_part).where(second_parts: { id: nil }).select(:id) })
+    @first_parts = FirstPart.joins(:make)
+                            .where(makes: { id: Make.left_outer_joins(:second_part)
+                                                .where(second_parts: { id: nil })
+                                                .select(:id) })
+                            .order(created_at: :desc)
   end
 
   def new

--- a/app/controllers/makes_controller.rb
+++ b/app/controllers/makes_controller.rb
@@ -1,12 +1,13 @@
 class MakesController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_make, only: %i[show edit update destroy]
+  before_action :authorize_user!, only: %i[edit update destroy]
 
   def index
-    @makes = Make.all
+    @makes = Make.order(created_at: :desc)
   end
 
   def show
-    @make = Make.find(params[:id])
   end
 
   def new
@@ -34,7 +35,31 @@ class MakesController < ApplicationController
     end
   end
 
+  def edit
+  end
+
+  def update
+    if @make.update(make_params)
+      redirect_to @make, notice: 'Make was successfully updated.'
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @make.destroy
+    redirect_to makes_path, notice: 'Make was successfully destroyed.'
+  end
+
   private
+
+  def set_make
+    @make = Make.find(params[:id])
+  end
+
+  def authorize_user!
+    redirect_to makes_path, alert: 'You are not authorized to perform this action.' unless @make.user == current_user
+  end
 
   def make_params
     params.require(:make).permit(

--- a/app/controllers/second_parts_controller.rb
+++ b/app/controllers/second_parts_controller.rb
@@ -4,7 +4,11 @@ class SecondPartsController < ApplicationController
 
   # first_partsが存在しないmakeのみを取得
   def index
-    @second_parts = SecondPart.joins(:make).where(makes: { id: Make.left_outer_joins(:first_part).where(first_parts: { id: nil }).select(:id) })
+    @second_parts = SecondPart.joins(:make)
+                              .where(makes: { id: Make.left_outer_joins(:first_part)
+                                                  .where(first_parts: { id: nil })
+                                                  .select(:id) })
+                              .order(created_at: :desc)
   end
 
   def new

--- a/app/views/fetch_ais/edit.html.erb
+++ b/app/views/fetch_ais/edit.html.erb
@@ -1,2 +1,39 @@
-<h1>FetchAis#edit</h1>
-<p>Find me in app/views/fetch_ais/edit.html.erb</p>
+<!-- app/views/fetch_ais/edit.html.erb -->
+<div class="flex justify-center items-start min-h-screen pt-8">
+  <div class="card card-compact w-96 bg-base-100 shadow-xl text-center">
+    <h1 class="text-3xl font-bold mb-4 text-center"><%= t('fetch_ais.edit.title') %></h1>
+    <div class="card-body">
+      <!-- AI response -->
+      <% if @fetch_ai.response.present? %>
+        <% quote = @fetch_ai.response.match(/<quote>(.*?)<\/quote>/m)[1].strip rescue nil %>
+        <% info = @fetch_ai.response.match(/<info>(.*?)<\/info>/m)[1].strip rescue nil %>
+        
+        <% if quote %>
+          <div class="chat chat-start flex justify-start mb-4">
+            <div class="chat-bubble bg-gray-800 text-white p-4 rounded-lg max-w-md" style="text-align: left; font-weight: bold;">
+              <%= quote %>
+            </div>
+          </div>
+        <% end %>
+
+        <% if info %>
+          <div class="chat chat-start flex justify-start mb-4">
+            <div class="chat-bubble bg-gray-800 text-white p-4 rounded-lg max-w-md" style="text-align: left; font-weight: normal;">
+              <%= info %>
+            </div>
+          </div>
+        <% end %>
+      <% end %>
+      <!-- delete and back to show -->
+      <div class="chat chat-end flex justify-end">
+        <div class="chat-bubble bg-blue-600 text-white p-4 rounded-lg max-w-md">
+          <div class="mt-4">
+            <%= link_to '詳細', fetch_ai_path(@fetch_ai), class: 'btn btn-primary flex items-center justify-center gap-2 mt-2' %>
+            <br>
+            <%= button_to '削除', fetch_ai_path(@fetch_ai), method: :delete, data: { confirm: '本当に削除しますか？' }, class: "btn btn-secondary" %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/fetch_ais/index.html.erb
+++ b/app/views/fetch_ais/index.html.erb
@@ -1,30 +1,54 @@
+<!-- app/views/fetch_ais/index.html.erb -->
 <% if user_signed_in? %>
-  <div class="flex justify-center items-center min-h-screen pt-8 flex-col"> <!-- flex-colを追加、items-startをitems-centerに変更 -->
-    <h1 class="text-3xl font-bold mb-4 text-center"><%= t('fetch_ais.show.title') %></h1>
-    <% @fetch_ais.each do |fetch_ai| %>
-      <% if fetch_ai.response.present? %>
-        <div class="card bg-base-100 shadow-xl w-auto my-2 mx-auto" style="width: 100%; max-width: 640px;"> <!-- mx-autoでカードを中央に配置 -->
-          <div class="card-body">
-            <div class="chat chat-start flex justify-start">
-              <div class="chat-bubble bg-gray-800 text-white p-4 rounded-lg max-w-md">
-                <%= fetch_ai.response %>
-              </div>
-            </div>
-            <div class="chat chat-end flex justify-end"> <!-- justify-endで右に配置 -->
-              <div class="chat-bubble bg-blue-600 text-white p-4 rounded-lg max-w-md">
-                <%= button_to 'destroy', fetch_ai_path(fetch_ai), method: :delete, data: { confirm: '本当に削除しますか？' }, class: 'btn text-white mt-4', style: 'background-color: #1f2937;' %>
-                <div class="mt-4">
-                  <%= link_to "https://twitter.com/share?url=https://wordpass-ldtw.onrender.com&text=今日は〇〇さんに励まされました！%0a%0a#{fetch_ai.response}", target: '_blank', class: "btn btn-info flex items-center justify-center gap-2" do %>
-                    <i class="fa-brands fa-x-twitter"></i>
-                    <span><%= t('fetch_ais.show.share') %></span>
-                  <% end %>
+  <div class="flex justify-center items-start min-h-screen pt-8">
+    <div class="card card-compact w-96 bg-base-100 shadow-xl text-center">
+      <%= render 'shared/ai_buttons', fetch_ai: @fetch_ai %>
+      <br><br>
+      <h1 class="text-3xl font-bold mb-4 text-center"><%= t('fetch_ais.index.title') %></h1>
+      <div class="card-body">
+        <% @fetch_ais.each do |fetch_ai| %>
+          <% if fetch_ai.response.present? %>
+            <div class="card bg-base-100 shadow-xl w-auto my-2 mx-auto" style="width: 100%; max-width: 640px;">
+              <div class="card-body">
+                <!-- AI response -->
+                <% quote = fetch_ai.response.match(/<quote>(.*?)<\/quote>/m)[1].strip rescue nil %>
+                <% info = fetch_ai.response.match(/<info>(.*?)<\/info>/m)[1].strip rescue nil %>
+                
+                <% if quote %>
+                  <div class="chat chat-start flex justify-start mb-4">
+                    <div class="chat-bubble bg-gray-800 text-white p-4 rounded-lg max-w-md" style="text-align: left; font-weight: bold;">
+                      <%= quote %>
+                    </div>
+                  </div>
+                <% end %>
+
+                <% if info %>
+                  <div class="chat chat-start flex justify-start mb-4">
+                    <div class="chat-bubble bg-gray-800 text-white p-4 rounded-lg max-w-md" style="text-align: left; font-weight: normal;">
+                      <%= info %>
+                    </div>
+                  </div>
+                <% end %>
+
+                <!-- share, delete, and show details -->
+                <div class="chat chat-end flex justify-end">
+                  <div class="chat-bubble bg-blue-600 text-white p-4 rounded-lg max-w-md text-left">
+                    <div class="mt-4">
+                      <%= link_to '詳細', fetch_ai_path(fetch_ai), class: 'btn btn-primary flex items-center justify-center gap-2 mt-2' %>
+                      <br>
+                      <%= link_to "https://twitter.com/share?url=https://wordpass-ldtw.onrender.com&text=今日は〇〇さんに励まされました！%0a%0a#{quote}", target: '_blank', class: "btn btn-info flex items-center justify-center gap-2 mt-2" do %>
+                        <i class="fa-brands fa-x-twitter"></i>
+                        <span><%= t('fetch_ais.show.share') %></span>
+                      <% end %>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        </div>
-      <% end %>
-    <% end %>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
   </div>
 <% else %>
   <p>サインインしてください。</p>

--- a/app/views/fetch_ais/show.html.erb
+++ b/app/views/fetch_ais/show.html.erb
@@ -1,22 +1,41 @@
 <!-- app/views/fetch_ais/show.html.erb -->
 <div class="flex justify-center items-start min-h-screen pt-8">
-  <div class="card bg-base-100 shadow-xl w-auto" style="width: 32%; max-width: 1280px;">
-  <h1 class="text-xl font-bold mb-4 text-center"><%= t('fetch_ais.show.title') %></h1>
+  <div class="card card-compact w-96 bg-base-100 shadow-xl text-center">
+    <h1 class="text-3xl font-bold mb-4 text-center"><%= t('fetch_ais.show.title') %></h1>
     <div class="card-body">
       <!-- AI response -->
-      <div class="chat chat-start flex justify-start">
-        <div class="chat-bubble bg-gray-800 text-white p-4 rounded-lg max-w-md">
-          <%= @fetch_ai.response %>
-        </div>
-      </div>
+      <% if @fetch_ai.response.present? %>
+        <% quote = @fetch_ai.response.match(/<quote>(.*?)<\/quote>/m)[1].strip rescue nil %>
+        <% info = @fetch_ai.response.match(/<info>(.*?)<\/info>/m)[1].strip rescue nil %>
+        
+        <% if quote %>
+          <div class="chat chat-start flex justify-start mb-4">
+            <div class="chat-bubble bg-gray-800 text-white p-4 rounded-lg max-w-md" style="text-align: left; font-weight: bold;">
+              <%= quote %>
+            </div>
+          </div>
+        <% end %>
+
+        <% if info %>
+          <div class="chat chat-start flex justify-start mb-4">
+            <div class="chat-bubble bg-gray-800 text-white p-4 rounded-lg max-w-md" style="text-align: left; font-weight: normal;">
+              <%= info %>
+            </div>
+          </div>
+        <% end %>
+      <% end %>
       <!-- share -->
       <div class="chat chat-end flex justify-end">
         <div class="chat-bubble bg-blue-600 text-white p-4 rounded-lg max-w-md">
           <div class="mt-4">
-            <%= link_to "https://twitter.com/share?url=https://wordpass-ldtw.onrender.com&text=今日は〇〇さんに励まされました！%0a%0a#{@fetch_ai.response}", target: '_blank', class: "btn btn-info flex items-center justify-center gap-2" do %>
+            <%= link_to "https://twitter.com/share?url=https://wordpass-ldtw.onrender.com&text=名言の海を探索したら、この方の言葉を見つけたよ！%0a%0a#{quote}", target: '_blank', class: "btn btn-info flex items-center justify-center gap-2" do %>
               <i class="fa-brands fa-x-twitter"></i>
               <span><%= t('fetch_ais.show.share') %></span>
             <% end %>
+            <br>
+            <%= link_to '名言一覧に戻る', fetch_ais_path, class: 'btn btn-secondary flex items-center justify-center gap-2 mt-2' %>
+            <br>
+            <%= link_to '編集', edit_fetch_ai_path(@fetch_ai), class: 'btn btn-warning flex items-center justify-center gap-2 mt-2' %>          
           </div>
         </div>
       </div>

--- a/app/views/first_parts/index.html.erb
+++ b/app/views/first_parts/index.html.erb
@@ -23,7 +23,10 @@
         </div>
 
         <div class="mt-4 flex justify-center space-x-4">
-          <%= link_to '下の句を作る', make_path(first_part.make), class: 'btn btn-secondary' %>
+          <%= link_to '下の句を作る', make_path(first_part.make), class: 'btn btn-primary' %>
+        </div>
+        <div class="mt-4">
+          <%= link_to '戻る', makes_path, class: 'btn btn-secondary' %>
         </div>
       </div>
     </div>

--- a/app/views/first_parts/new.html.erb
+++ b/app/views/first_parts/new.html.erb
@@ -1,14 +1,24 @@
-<h1>Add First Part</h1>
+<!-- app/views/first_parts/new.html.erb -->
+<br>
+<h1 class="text-3xl font-bold mb-4 text-center">Add FirstPart</h1>
+<div class="flex justify-center items-center">
+  <div class="card card-compact w-full max-w-lg bg-base-100 shadow-xl p-8">
+    <%= form_with(model: [@make, @first_part], url: make_first_part_path(@make), local: true) do |form| %>
+      <div class="mb-4">
+        <div class="form-control">
+          <%= form.label :content, "First Part", class: "label" %>
+          <%= form.text_area :content, class: "textarea textarea-bordered w-full" %>
+        </div>
+      </div>
+      <div class="actions">
+        <%= form.submit '作成', class: 'btn btn-primary w-full' %>
+      </div>
+    <% end %>
 
-<%= form_with(model: [@make, @first_part], url: make_first_part_path(@make), local: true) do |form| %>
-  <div class="field">
-    <%= form.label :content, "First Part" %>
-    <%= form.text_area :content %>
+    <div class="mt-4">
+      <%= link_to '一覧に戻る', makes_path, class: 'btn btn-secondary w-full' %>
+      <br><br>
+      <%= link_to '詳細に戻る', make_path(@make), class: 'btn btn-secondary w-full' %>
+    </div>
   </div>
-
-  <div class="actions">
-    <%= form.submit 'Add First Part', class: 'btn btn-primary' %>
-  </div>
-<% end %>
-
-<%= link_to 'Back to Make', make_path(@make), class: 'btn btn-secondary' %>
+</div>

--- a/app/views/makes/edit.html.erb
+++ b/app/views/makes/edit.html.erb
@@ -1,2 +1,39 @@
-<h1>Makes#edit</h1>
-<p>Find me in app/views/makes/edit.html.erb</p>
+<!-- app/views/makes/edit.html.erb -->
+<br>
+<h1 class="text-3xl font-bold mb-4 text-center"><%= t('makes.edit.title') %></h1>
+<div class="flex justify-center items-center">
+  <div class="card card-compact w-full max-w-lg bg-base-100 shadow-xl p-8">
+    <h1 class="text-2xl font-bold mb-4">Edit Make #<%= @make.id %></h1>
+
+    <%= form_with(model: @make, local: true) do |form| %>
+      <div class="mb-4">
+        <%= form.fields_for :first_part do |fp_form| %>
+          <div class="form-control">
+            <%= fp_form.label :content, t('makes.edit.first_parts'), class: "label" %>
+            <%= fp_form.text_area :content, class: "textarea textarea-bordered w-full", value: @make.first_part&.content %>
+          </div>
+        <% end %>
+      </div>
+
+      <div class="mb-4">
+        <%= form.fields_for :second_part do |sp_form| %>
+          <div class="form-control">
+            <%= sp_form.label :content, t('makes.edit.second_parts'), class: "label" %>
+            <%= sp_form.text_area :content, class: "textarea textarea-bordered w-full", value: @make.second_part&.content %>
+          </div>
+        <% end %>
+      </div>
+
+      <div class="actions">
+        <%= form.submit "更新", class: 'btn btn-primary w-full' %>
+      </div>
+    <% end %>
+
+    <div class="mt-4">
+      <%= link_to "戻る", make_path(@make), class: 'btn btn-secondary w-full' %>
+    </div>
+    <div class="mt-4">
+      <%= button_to "削除", make_path(@make), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger w-full' %>
+    </div>
+  </div>
+</div>

--- a/app/views/makes/new.html.erb
+++ b/app/views/makes/new.html.erb
@@ -1,26 +1,39 @@
-<h1>New Make</h1>
+<!-- app/views/makes/new.html.erb -->
+<br>
+<h1 class="text-3xl font-bold mb-4 text-center"><%= t('makes.new.title') %></h1>
+<div class="flex justify-center items-center">
+  <div class="card card-compact w-full max-w-lg bg-base-100 shadow-xl p-8">
+    <%= form_with(model: @make, local: true) do |form| %>
+      <div class="mb-4">
+        <%= form.fields_for :first_part do |fp_form| %>
+          <div class="form-control">
+            <%= fp_form.label :content, t('makes.new.first_parts'), class: "label" %>
+            <%= fp_form.text_area :content, class: "textarea textarea-bordered w-full" %>
+            <%= fp_form.hidden_field :user_id, value: current_user.id %>
+          </div>
+        <% end %>
+      </div>
 
-<%= form_with(model: @make, local: true) do |form| %>
-  <%= form.fields_for :first_part do |fp_form| %>
-    <div class="field">
-      <%= fp_form.label :content, "First Part" %>
-      <%= fp_form.text_area :content %>
-      <%= fp_form.hidden_field :user_id, value: current_user.id %>
+      <div class="mb-4">
+        <%= form.fields_for :second_part do |sp_form| %>
+          <div class="form-control">
+            <%= sp_form.label :content, t('makes.new.second_parts'), class: "label" %>
+            <%= sp_form.text_area :content, class: "textarea textarea-bordered w-full" %>
+            <%= sp_form.hidden_field :user_id, value: current_user.id %>
+          </div>
+          <small class="text-gray-500">※上の句のみ、下の句のみ、両方、どれでも投稿できるよ！
+          <br>※ひとりで投稿する場合は、両方を選択しよう！
+          </small>
+        <% end %>
+      </div>
+
+      <div class="actions">
+        <%= form.submit t('makes.new.create'), class: 'btn btn-primary w-full' %>
+      </div>
+    <% end %>
+
+    <div class="mt-4">
+      <%= link_to t('makes.new.back'), makes_path, class: 'btn btn-secondary w-full' %>
     </div>
-  <% end %>
-
-  <%= form.fields_for :second_part do |sp_form| %>
-    <div class="field">
-      <%= sp_form.label :content, "Second Part" %>
-      <%= sp_form.text_area :content %>
-      <%= sp_form.hidden_field :user_id, value: current_user.id %>
-    </div>
-    <small>Second Part is optional</small>
-  <% end %>
-
-  <div class="actions">
-    <%= form.submit 'Create Make', class: 'btn btn-primary' %>
   </div>
-<% end %>
-
-<%= link_to 'Back to Makes', makes_path, class: 'btn btn-secondary' %>
+</div>

--- a/app/views/makes/show.html.erb
+++ b/app/views/makes/show.html.erb
@@ -1,24 +1,16 @@
-<h1 class="text-2xl font-bold mb-4">Make ##<%= @make.id %></h1>
+<!-- app/views/makes/show.html.erb -->
+<br>
+<h1 class="text-3xl font-bold mb-4 text-center"><%= t('makes.new.title') %></h1>
+<div class="flex justify-center items-center">
+  <div class="card card-compact w-full max-w-lg bg-base-100 shadow-xl p-8">
+  <h1 class="text-2xl font-bold mb-4">Make #<%= @make.id %></h1>
 
-<div class="make card shadow-lg p-4 mb-4">
-  <h2 class="text-xl font-semibold mb-2">
-    <%= @make.first_part&.content || '' %> <%= @make.second_part&.content || '' %>
-  </h2>
+    <h2 class="text-xl font-semibold mb-2">
+      <%= @make.first_part&.content || '' %> <%= @make.second_part&.content || '' %>
+    </h2>
 
-  <div class="user-info flex items-center mt-4 space-x-4">
-    <% if @make.first_part && @make.second_part && @make.first_part.user == @make.second_part.user %>
-      <div class="avatar">
-        <div class="rounded-full w-10 h-10">
-          <% if @make.first_part.user.avatar.present? %>
-            <%= image_tag @make.first_part.user.avatar.url %>
-          <% else %>
-            <%= image_tag 'default-avatar.png' %>
-          <% end %>
-        </div>
-      </div>
-      <span class="text-sm font-bold"><%= @make.first_part.user.name %></span>
-    <% else %>
-      <% if @make.first_part %>
+    <div class="user-info flex items-center mt-4 space-x-4">
+      <% if @make.first_part && @make.second_part && @make.first_part.user == @make.second_part.user %>
         <div class="avatar">
           <div class="rounded-full w-10 h-10">
             <% if @make.first_part.user.avatar.present? %>
@@ -28,24 +20,42 @@
             <% end %>
           </div>
         </div>
-        <span class="text-sm font-bold mr-4"><%= @make.first_part.user.name %></span>
-      <% end %>
-      <% if @make.second_part %>
-        <div class="avatar">
-          <div class="rounded-full w-10 h-10">
-            <% if @make.second_part.user.avatar.present? %>
-              <%= image_tag @make.second_part.user.avatar.url %>
-            <% else %>
-              <%= image_tag 'default-avatar.png' %>
-            <% end %>
+        <span class="text-sm font-bold"><%= @make.first_part.user.name %></span>
+      <% else %>
+        <% if @make.first_part %>
+          <div class="avatar">
+            <div class="rounded-full w-10 h-10">
+              <% if @make.first_part.user.avatar.present? %>
+                <%= image_tag @make.first_part.user.avatar.url %>
+              <% else %>
+                <%= image_tag 'default-avatar.png' %>
+              <% end %>
+            </div>
           </div>
-        </div>
-        <span class="text-sm font-bold"><%= @make.second_part.user.name %></span>
+          <span class="text-sm font-bold mr-4"><%= @make.first_part.user.name %></span>
+        <% end %>
+        <% if @make.second_part %>
+          <div class="avatar">
+            <div class="rounded-full w-10 h-10">
+              <% if @make.second_part.user.avatar.present? %>
+                <%= image_tag @make.second_part.user.avatar.url %>
+              <% else %>
+                <%= image_tag 'default-avatar.png' %>
+              <% end %>
+            </div>
+          </div>
+          <span class="text-sm font-bold"><%= @make.second_part.user.name %></span>
+        <% end %>
       <% end %>
-    <% end %>
-  </div>
+    </div>
 
-  <%= link_to 'Back to Makes', makes_path, class: 'btn btn-primary mt-4' %>
-  <%= link_to 'Add First Part', new_make_first_part_path(@make), class: 'btn btn-secondary mt-4' if @make.first_part.nil? %>
-  <%= link_to 'Add Second Part', new_make_second_part_path(@make), class: 'btn btn-secondary mt-4' if @make.second_part.nil? %>
+    <div class="actions mt-4">
+      <%= link_to '上の句を作る', new_make_first_part_path(@make), class: 'btn btn-primary w-full mt-4' if @make.first_part.nil? %>
+      <%= link_to '下の句を作る', new_make_second_part_path(@make), class: 'btn btn-primary w-full mt-4' if @make.second_part.nil? %>
+      <br><br>
+      <%= link_to '一覧に戻る', makes_path, class: 'btn btn-secondary w-full' %>
+      <br><br>
+      <%= link_to '編集する', edit_make_path, class: 'btn btn-secondary w-full' %>
+    </div>
+  </div>
 </div>

--- a/app/views/second_parts/index.html.erb
+++ b/app/views/second_parts/index.html.erb
@@ -23,7 +23,7 @@
         </div>
 
         <div class="mt-4 flex justify-center space-x-4">
-          <%= link_to '上の句を作る', make_path(second_part.make), class: 'btn btn-secondary' %>
+          <%= link_to '上の句を作る', make_path(second_part.make), class: 'btn btn-primary' %>
         </div>
       </div>
     </div>

--- a/app/views/second_parts/new.html.erb
+++ b/app/views/second_parts/new.html.erb
@@ -1,14 +1,24 @@
-<h1>Add Second Part</h1>
+<!-- app/views/second_parts/new.html.erb -->
+<br>
+<h1 class="text-3xl font-bold mb-4 text-center">Add Second Part</h1>
+<div class="flex justify-center items-center">
+  <div class="card card-compact w-full max-w-lg bg-base-100 shadow-xl p-8">
+    <%= form_with(model: [@make, @second_part], url: make_second_part_path(@make), local: true) do |form| %>
+      <div class="mb-4">
+        <div class="form-control">
+          <%= form.label :content, "Second Part", class: "label" %>
+          <%= form.text_area :content, class: "textarea textarea-bordered w-full" %>
+        </div>
+      </div>
+      <div class="actions">
+        <%= form.submit '作成', class: 'btn btn-primary w-full' %>
+      </div>
+    <% end %>
 
-<%= form_with(model: [@make, @second_part], url: make_second_part_path(@make), local: true) do |form| %>
-  <div class="field">
-    <%= form.label :content, "Second Part" %>
-    <%= form.text_area :content %>
+    <div class="mt-4">
+      <%= link_to '一覧に戻る', makes_path, class: 'btn btn-secondary w-full' %>
+      <br><br>
+      <%= link_to '詳細に戻る', make_path(@make), class: 'btn btn-secondary w-full' %>
+    </div>
   </div>
-
-  <div class="actions">
-    <%= form.submit 'Add Second Part', class: 'btn btn-primary' %>
-  </div>
-<% end %>
-
-<%= link_to 'Back to Make', make_path(@make), class: 'btn btn-secondary' %>
+</div>

--- a/app/views/shared/_ai_buttons.erb
+++ b/app/views/shared/_ai_buttons.erb
@@ -1,0 +1,54 @@
+<!-- app/views/shared/_personalized_buttons.html.erb -->
+<% if user_signed_in? %>
+  <div class="card-actions justify-center">
+    <%= button_to t('tops.get'), fetch_ais_path, method: :post, class: "btn btn-primary mt-4" %>
+  </div>
+  <button class="btn btn-primary mt-4" onclick="document.getElementById('my_modal_2').showModal()"><%= t('tops.personalize_get') %></button>
+  <dialog id="my_modal_2" class="modal">
+    <div class="modal-box text-center">
+      <form method="dialog">
+        <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
+      </form>
+      <h3 class="font-bold text-lg">パーソナライズ</h3>
+      <p class="py-4">セレクトボックスから適当なものを選んでください</p>
+      <%= form_with model: @fetch_ai, local: true, id: "personalize_form" do |form| %>
+        <%= form.hidden_field :prompt_type, value: 'personalized' %>
+        <div class="mb-3 text-center">
+          <%= form.label :mood, class: "form-label block mb-2 text-sm font-bold" %>
+          <%= form.select :mood, options_for_select(["元気", "落ち気味", "普通", "悲しい", "イライラ"], @fetch_ai.mood), {}, {class: "select select-bordered w-full max-w-xs"} %>
+        </div>
+        <div class="mb-3 text-center">
+          <%= form.label :schedule, class: "form-label block mb-2 text-sm font-bold" %>
+          <%= form.select :schedule, options_for_select(["仕事", "学習", "健康の事", "家庭の事", "趣味", "自己に関わること"], @fetch_ai.schedule), {}, {class: "select select-bordered w-full max-w-xs"} %>
+        </div>
+        <div class="mb-3 text-center">
+          <%= form.label :how, class: "form-label block mb-2 text-sm font-bold" %>
+          <%= form.select :how, options_for_select(["心に刺さる名言", "心に寄り添う名言", "クスっと笑ってしまう名言", "厳しい名言"], @fetch_ai.how), {}, {class: "select select-bordered w-full max-w-xs"} %>
+        </div>
+        <div class="mb-3 text-center">
+          <%= form.label :popularity, class: "form-label block mb-2 text-sm font-bold" %>
+          <%= form.select :popularity, options_for_select(["メジャー", "マイナー", "メジャーでもマイナーでもないよう"], @fetch_ai.popularity), {}, {class: "select select-bordered w-full max-w-xs"} %>
+        </div>
+        <div class="mb-3 text-center">
+          <%= form.label :quote_type, class: "form-label block mb-2 text-sm font-bold" %>
+          <%= form.select :quote_type, options_for_select(["漫画", "映画", "アニメ", "書籍", "偉人", "有名人"], @fetch_ai.quote_type), {}, {class: "select select-bordered w-full max-w-xs"} %>
+        </div>
+        <div class="modal-action justify-center">
+          <%= form.submit t('tops.receive'), class: "btn btn-primary mt-4" %>
+        </div>
+      <% end %>
+    </div>
+  </dialog>
+  <!-- yuriraccoモーダル -->
+  <dialog id="loading_modal" class="modal">
+    <div class="modal-box text-center">
+      <figure class="px-10 pt-10">
+        <img src="/20240514_164506.GIF" alt="Shoes" class="rounded-xl w-48 h-48" />
+      </figure>
+    </div>
+  </dialog>
+<% else %>
+  <div class="card-actions justify-center">
+    <%= button_to t('tops.get'), fetch_ais_path, method: :post, class: "btn btn-primary mt-4" %>
+  </div>
+<% end %>

--- a/app/views/tops/index.html.erb
+++ b/app/views/tops/index.html.erb
@@ -1,3 +1,4 @@
+<!-- app/views/tops/index.html.erb -->
 <div class="flex flex-col justify-center items-center min-h-screen pt-8">
   <div class="card card-compact w-96 bg-base-100 shadow-xl text-center">
     <h1 class="text-3xl font-bold mb-4"><%= t('tops.title') %></h1>
@@ -12,59 +13,7 @@
       様々な作品からの名言や格言を受け取ろう！<br>
       日々の生活において必要な刺激となる言葉を通じて<br>
       心のエネルギーを蓄えよう！</p>
-      <% if user_signed_in? %>
-        <div class="card-actions justify-center">
-          <%= button_to t('tops.get'), fetch_ais_path, method: :post, class: "btn btn-primary mt-4" %>
-        </div>
-        <button class="btn btn-primary mt-4" onclick="document.getElementById('my_modal_2').showModal()"><%= t('tops.personalize_get') %></button>
-        <dialog id="my_modal_2" class="modal">
-          <div class="modal-box text-center">
-            <form method="dialog">
-              <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
-            </form>
-            <h3 class="font-bold text-lg">パーソナライズ</h3>
-            <p class="py-4">セレクトボックスから適当なものを選んでください</p>
-            <%= form_with model: @fetch_ai, local: true, id: "personalize_form" do |form| %>
-              <%= form.hidden_field :prompt_type, value: 'personalized' %>
-              <div class="mb-3 text-center">
-                <%= form.label :mood, class: "form-label block mb-2 text-sm font-bold" %>
-                <%= form.select :mood, options_for_select(["元気", "落ち気味", "普通", "悲しい", "イライラ"], @fetch_ai.mood), {}, {class: "select select-bordered w-full max-w-xs"} %>
-              </div>
-              <div class="mb-3 text-center">
-                <%= form.label :schedule, class: "form-label block mb-2 text-sm font-bold" %>
-                <%= form.select :schedule, options_for_select(["仕事", "学習", "健康の事", "家庭の事", "趣味", "自己に関わること"], @fetch_ai.schedule), {}, {class: "select select-bordered w-full max-w-xs"} %>
-              </div>
-              <div class="mb-3 text-center">
-                <%= form.label :how, class: "form-label block mb-2 text-sm font-bold" %>
-                <%= form.select :how, options_for_select(["心に刺さる名言", "心に寄り添う名言", "クスっと笑ってしまう名言", "厳しい名言"], @fetch_ai.how), {}, {class: "select select-bordered w-full max-w-xs"} %>
-              </div>
-              <div class="mb-3 text-center">
-                <%= form.label :popularity, class: "form-label block mb-2 text-sm font-bold" %>
-                <%= form.select :popularity, options_for_select(["メジャー", "マイナー", "メジャーでもマイナーでもないよう"], @fetch_ai.popularity), {}, {class: "select select-bordered w-full max-w-xs"} %>
-              </div>
-              <div class="mb-3 text-center">
-                <%= form.label :quote_type, class: "form-label block mb-2 text-sm font-bold" %>
-                <%= form.select :quote_type, options_for_select(["漫画", "映画", "アニメ", "書籍", "偉人", "有名人"], @fetch_ai.quote_type), {}, {class: "select select-bordered w-full max-w-xs"} %>
-              </div>
-              <div class="modal-action justify-center">
-                <%= form.submit t('tops.receive'), class: "btn btn-primary mt-4" %>
-              </div>
-            <% end %>
-          </div>
-        </dialog>
-        <!-- yuriraccoモーダル -->
-        <dialog id="loading_modal" class="modal">
-          <div class="modal-box text-center">
-            <figure class="px-10 pt-10">
-              <img src="/20240514_164506.GIF" alt="Shoes" class="rounded-xl w-48 h-48" />
-            </figure>
-          </div>
-        </dialog>
-      <% else %>
-        <div class="card-actions justify-center">
-          <%= button_to t('tops.get'), fetch_ais_path, method: :post, class: "btn btn-primary mt-4" %>
-        </div>
-      <% end %>
+      <%= render 'shared/ai_buttons', fetch_ai: @fetch_ai %>
       <br><br><br><br>
       <h2 class="card-title justify-center">名言おった？</h2>
       <figure class="px-10 pt-10">
@@ -74,28 +23,54 @@
   </div>
   <div class="card card-compact w-96 bg-base-100 shadow-xl text-center">
     <br><br>
-    <h1 class="text-2xl font-bold mb-4">サインインすると...</h1>
-    <br>
-    <div class="card-body">
-      <h2 class="card-title justify-center">今の自分に合った名言がもらえるよ！</h2>
+    <% if user_signed_in? %>
+      <h1 class="text-2xl font-bold mb-4">名言の海にようこそ！</h1>
       <br>
-      <p>プルダウン式の項目から<br>
-      気分、予定、どんな名言か<br>
-      メジャーなのかマイナーな作品なのか<br>
-      偉人、有名人、名著、映画、漫画、アニメなのか<br>
-      自分で選択できるよ！</p>
-      <div class="card-actions justify-center">
-        <%= link_to t('tops.signup'), new_user_session_path, method: :post, class: "btn btn-primary mt-4" %>
+      <div class="card-body">
+        <h2 class="card-title justify-center">あなたに合った名言を見つけよう！</h2>
+        <br>
+        <p>プルダウン式の項目から<br>
+        気分、予定、どんな名言か<br>
+        メジャーなのかマイナーな作品なのか<br>
+        偉人、有名人、名著、映画、漫画、アニメなのか<br>
+        自分で選択できるよ！</p>
+        <div class="card-actions justify-center">
+          <%= link_to '名言の海に行く', fetch_ais_path, class: "btn btn-primary mt-4" %>
+        </div>
+        <br><br>
+        <h2 class="card-title justify-center">名言作成！</h2>
+        <br>
+        <p>自分の好きな名言の作成（投稿）<br>
+        誰かと協力しての作成（投稿）<br>
+        みんなで名言を共有しよう！</p>
+        <div class="card-actions justify-center">
+          <%= link_to '名言を作成', makes_path, class: "btn btn-primary mt-4" %>
+        </div>
       </div>
-      <br><br>
-      <h2 class="card-title justify-center">名言作成もできる！></h2>
+    <% else %>
+      <h1 class="text-2xl font-bold mb-4">サインインすると...</h1>
       <br>
-      <p>自分の好きな名言の作成（投稿）<br>
-      誰かと協力しての作成（投稿）<br>
-      みんなで名言を共有しよう！</p>
-      <div class="card-actions justify-center">
-        <%= link_to t('tops.signup'), new_user_session_path, method: :post, class: "btn btn-primary mt-4" %>
+      <div class="card-body">
+        <h2 class="card-title justify-center">今の自分に合った名言がもらえるよ！</h2>
+        <br>
+        <p>プルダウン式の項目から<br>
+        気分、予定、どんな名言か<br>
+        メジャーなのかマイナーな作品なのか<br>
+        偉人、有名人、名著、映画、漫画、アニメなのか<br>
+        自分で選択できるよ！</p>
+        <div class="card-actions justify-center">
+          <%= link_to t('tops.signup'), new_user_session_path, method: :post, class: "btn btn-primary mt-4" %>
+        </div>
+        <br><br>
+        <h2 class="card-title justify-center">名言作成もできる！</h2>
+        <br>
+        <p>自分の好きな名言の作成（投稿）<br>
+        誰かと協力しての作成（投稿）<br>
+        みんなで名言を共有しよう！</p>
+        <div class="card-actions justify-center">
+          <%= link_to t('tops.signup'), new_user_session_path, method: :post, class: "btn btn-primary mt-4" %>
+        </div>
       </div>
-    </div>
+    <% end %>
   </div>
 </div>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,7 +27,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fall back to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -60,7 +60,7 @@ ja:
     get: すぐに受け取る
     personalize_get: パーソナライズして受け取る
     receive: 受け取る
-    signup: サインイン
+    signup: サインアップ
   profiles:
     show:
       title: プロフィール
@@ -69,9 +69,13 @@ ja:
       title: プロフィール編集
       update: 更新
   fetch_ais:
+    index:
+      title: 受け取った名言一覧
     show:
-      title: AIから受け取った名言一覧
+      title: 受け取った名言
       share: シェア
+    edit:
+      title: 受け取った名言を編集
   makes:
     index:
       title: 名言を作ろう！
@@ -81,3 +85,9 @@ ja:
       detail: 詳細
       add_first_part: 上の句を作る
       add_second_part: 下の句を作る
+    new:
+      title: 名言作成
+      create: 作成
+      back: 一覧に戻る
+      first_parts: 上の句
+      second_parts: 下の句


### PR DESCRIPTION
# 概要
名言作成、削除＆編集機能の追加
その他修正
## 実装内容
- [x] pipelineエラーの修正（名言作成機能でのエラー）
- [x] Xシェア時の文言の修正
- [x] トップページも文言の分岐の修正
- [x] パーシャルファイルの作成
`app/views/shared/_ai_buttons.html.erb`
- [x] AIからの名言取得のプロンプト調整、それに伴ったビューの調整
- [x] 名言作成、各コントローラの修正
- [x] 名言作成、各ページの修正
## 確認ポイント
- [x] 自分の関わった名言に関して削除、編集が可能
- [x] 自分の関わっていない名言を編集しようとすると、リダイレクトされる
- [x] AIからの名言取得での名言とそれ以外の実装でチャットバブルを分かれている
<img width="926" alt="スクリーンショット 2024-05-15 12 12 48" src="https://github.com/daichi3102/wordpass/assets/149915927/6bc13b26-d016-4c2c-b998-2d31d04553a1">

実装ログ [Notion](https://www.notion.so/29-fc9ad59369294ac8ae54aa28869f5461)
closes #29 