### PR TITLE
ボタン、表示方法の修正

### DIFF
--- a/app/views/fetch_ais/edit.html.erb
+++ b/app/views/fetch_ais/edit.html.erb
@@ -29,7 +29,7 @@
                 <div class="chat chat-end flex justify-end">
                   <div class="chat-bubble bg-secondary text-white p-4 rounded-lg max-w-md text-left">
                     <div class="mt-4">
-                      <%= link_to '詳細', fetch_ai_path(@fetch_ai), class: 'btn btn-neutral flex items-center justify-center gap-2 mt-2' %>
+                      <%= link_to '戻る', fetch_ai_path(@fetch_ai), class: 'btn btn-neutral flex items-center justify-center gap-2 mt-2' %>
                       <br>
                       <%= button_to '削除', fetch_ai_path(@fetch_ai), method: :delete, data: { confirm: '本当に削除しますか？' }, class: "btn btn-info" %>
                     </div>

--- a/app/views/makes/show.html.erb
+++ b/app/views/makes/show.html.erb
@@ -6,7 +6,8 @@
     <div class="card-body bg-base-100 shadow-xl p-8">
 
       <h2 class="text-3xl font-semibold mb-2">
-        <%= @make.first_part&.content || '' %> <%= @make.second_part&.content || '' %>
+        <div><%= @make.first_part&.content || '' %></div>
+        <div><%= @make.second_part&.content || '' %></div>
       </h2>
 
       <div class="user-info flex flex-col items-center mt-4 space-x-4">


### PR DESCRIPTION
# 概要
ボタン、表示方法の修正
## 実装内容
- [x] 名言取得機能、編集画面のボタンの名称を"詳細"から"戻る"に変更
- [x] 名言作成機能、詳細画面にて上の句、下の句を二行で表示

