### PR TITLE
AIからの名言取得機能において、前回自分の選んだ項目が値として残るようにする（プレースフォルダー）

### DIFF
--- a/app/views/shared/_ai_button.html.erb
+++ b/app/views/shared/_ai_button.html.erb
@@ -1,14 +1,17 @@
-<!-- app/views/shared/_personalized_buttons.html.erb -->
+<!-- app/views/shared/_ai_buttons.html.erb -->
 <% if user_signed_in? %>
+
   <div class="card-actions justify-center">
     <%= button_to t('tops.get'), fetch_ais_path, method: :post, class: "btn btn-primary mt-4 w-full max-w-xs" %>
   </div>
   <p class="py-4">※ランダムに名言を提供するよ</p>
   <br>
+
   <div class="card-actions justify-center">
     <button class="btn btn-primary mt-4 w-auto" onclick="document.getElementById('my_modal_2').showModal()"><%= t('tops.custom_get') %></button>
   </div>
   <p class="py-4">※指定した条件に合った名言を提供するよ</p>
+
   <dialog id="my_modal_2" class="modal">
     <div class="modal-box text-center">
       <form method="dialog">
@@ -25,6 +28,7 @@
         <div class="mb-3 text-center">
           <%= form.label :schedule, class: "form-label block mb-2 text-sm font-bold" %>
           <%= form.select :schedule, options_for_select(["仕事", "学習", "健康の事", "家庭の事", "趣味", "自己に関わること"], @fetch_ai.schedule), {}, {class: "select select-bordered w-full max-w-xs"} %>
+        </div>
         <div class="mb-3 text-center">
           <%= form.label :how, class: "form-label block mb-2 text-sm font-bold" %>
           <%= form.select :how, options_for_select(["心に刺さる名言", "心に寄り添う名言", "クスっと笑ってしまう名言", "厳しい名言", "恋愛に関する名言", "人生に関する名言"], @fetch_ai.how), {}, {class: "select select-bordered w-full max-w-xs"} %>
@@ -43,6 +47,7 @@
       <% end %>
     </div>
   </dialog>
+
 <!-- yuriraccoモーダル -->
 <dialog id="loading_modal" class="modal flex items-center justify-center">
   <div class="modal-box text-center flex flex-col items-center justify-center">
@@ -51,6 +56,7 @@
     </figure>
   </div>
 </dialog>
+
 <% else %>
   <div class="card-actions justify-center">
     <%= button_to t('tops.get'), fetch_ais_path, method: :post, class: "btn btn-primary mt-4 w-full max-w-xs" %>


### PR DESCRIPTION
# 概要
AIからの名言取得機能において、前回自分の選んだ項目が値として残るようにする（プレースフォルダー）
## 実装内容
- [x] コントローラの`create`アクションの修正
- [x] ビューの修正
## 確認ポイント
- [x] 前回の入力値が、次に取得する時に残っていること

1回目の入力時
![6bb752bde24d03d37c5177ee455c3dba](https://github.com/daichi3102/wordpass/assets/149915927/047907d5-7eb6-4433-8de3-b7340ec3cef7)

2回目の時に残っている
![4b67f13d30632a6bbc86e8959110b97b](https://github.com/daichi3102/wordpass/assets/149915927/33226d89-13ab-4d36-8fbe-abf7a87abbff)

実装ログ [Notion](https://www.notion.so/52c43766341c4e8994140eeb81734e9a)
closes #112 