### PR TITLE
みんなの作成した名言一覧ページの改善

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,8 @@ gem 'httparty'
 
 gem 'meta-tags'
 
+gem 'kaminari'
+
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem 'rails', '~> 7.1.3', '>= 7.1.3.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,6 +197,18 @@ GEM
     json (2.7.2)
     jwt (2.8.1)
       base64
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.3)
     loofah (2.22.0)
       crass (~> 1.0.2)
@@ -443,6 +455,7 @@ DEPENDENCIES
   httparty
   jbuilder
   jsbundling-rails
+  kaminari
   meta-tags
   omniauth-google-oauth2
   omniauth-rails_csrf_protection

--- a/app/controllers/first_parts_controller.rb
+++ b/app/controllers/first_parts_controller.rb
@@ -2,7 +2,7 @@ class FirstPartsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
   before_action :set_make, only: %i[new create]
   before_action :set_make_and_first_part, only: %i[edit update]
-  before_action :authorize_user!, only: %i[show edit update destroy]
+  before_action :authorize_user!, only: %i[edit update]
 
   # second_partsが存在しないmakeのみを取得
   def index
@@ -11,6 +11,7 @@ class FirstPartsController < ApplicationController
                                                 .where(second_parts: { id: nil })
                                                 .select(:id) })
                             .order(created_at: :desc)
+                            .page(params[:page])
   end
 
   def new

--- a/app/controllers/makes_controller.rb
+++ b/app/controllers/makes_controller.rb
@@ -2,10 +2,10 @@ class MakesController < ApplicationController
   # except: [:index]でindexアクションのみログインしていなくてもアクセスできる
   before_action :authenticate_user!, except: [:index]
   before_action :set_make, only: %i[show edit update destroy]
-  before_action :authorize_user!, only: %i[show edit update destroy]
+  before_action :authorize_user!, only: %i[show edit update]
 
   def index
-    @makes = Make.includes(:likes).order(created_at: :desc)
+    @makes = Make.includes(:likes).order(created_at: :desc).page(params[:page])
     @make = Make.new
     @make.build_first_part
     @make.build_second_part

--- a/app/controllers/second_parts_controller.rb
+++ b/app/controllers/second_parts_controller.rb
@@ -2,7 +2,7 @@ class SecondPartsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
   before_action :set_make, only: %i[new create]
   before_action :set_make_and_second_part, only: %i[edit update]
-  before_action :authorize_user!, only: %i[show edit update destroy]
+  before_action :authorize_user!, only: %i[edit update]
 
   # first_partsが存在しないmakeのみを取得
   def index
@@ -11,6 +11,7 @@ class SecondPartsController < ApplicationController
                                                   .where(first_parts: { id: nil })
                                                   .select(:id) })
                               .order(created_at: :desc)
+                              .page(params[:page])
   end
 
   def new

--- a/app/views/first_parts/index.html.erb
+++ b/app/views/first_parts/index.html.erb
@@ -28,6 +28,7 @@
               <button class="btn btn-primary" onclick="document.getElementById('second_part_modal_<%= first_part.make.id %>').showModal()"><%= t('makes.add_second_part') %></button>
             <% end %>
           </div>
+          <%= paginate @first_parts%>
         </div>
       </div>
       <!-- モーダルをレンダリング -->

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,9 @@
+<%# Link to the "First" page
+  - available local variables
+    url:           url to the first page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote, class: "bg-white hover:bg-gray-100 text-gray-800 font-light py-2 px-4 border border-gray-400 rounded shadow" %>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,8 @@
+<%# Non-link tag that stands for skipped pages...
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="tracking-widest text-gray-600 px-2"><%= t('views.pagination.truncate').html_safe %></span>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,9 @@
+<%# Link to the "Last" page
+  - available local variables
+    url:           url to the last page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote, class: "bg-white hover:bg-gray-100 text-gray-800 font-light py-2 px-4 border border-gray-400 rounded shadow" %>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,9 @@
+<%# Link to the "Next" page
+  - available local variables
+    url:           url to the next page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote, class: "bg-white hover:bg-gray-100 text-gray-800 font-light py-2 px-4 border border-gray-400 rounded shadow" %>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,14 @@
+<%# Link showing page number
+  - available local variables
+    page:          a page object for "this" page
+    url:           url to this page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<% if page.current? %>
+  <span class="bg-indigo-400 text-white px-4 py-3 rounded"><%= page %></span>
+<% else %>
+  <%= link_to page, url, remote: remote, rel: page.rel, class: "px-4 text-gray-800 font-light" %>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,25 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+-%>
+<%= paginator.render do -%>
+  <nav class="flex items-center justify-between m-10" role="navigation" aria-label="pager">
+    <%= first_page_tag unless current_page.first? %>
+    <%= prev_page_tag unless current_page.first? %>
+    <% each_page do |page| -%>
+      <% if page.display_tag? -%>
+        <%= page_tag page %>
+      <% elsif !page.was_truncated? -%>
+        <%= gap_tag %>
+      <% end -%>
+    <% end -%>
+    <% unless current_page.out_of_range? %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    <% end %>
+  </nav>
+<% end -%>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,10 @@
+<%# Link to the "Previous" page
+  - available local variables
+    url:           url to the previous page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+
+<%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote, class: "bg-white hover:bg-gray-100 text-gray-800 font-light py-2 px-4 border border-gray-400 rounded shadow" %>

--- a/app/views/makes/index.html.erb
+++ b/app/views/makes/index.html.erb
@@ -14,76 +14,79 @@
         <button class="btn btn-primary" onclick="document.getElementById('make_modal').showModal()"><%= t('defaults.create') %></button>
       <% end %>
       <br>
-      <div class="flex space-x-4">
-        <%= link_to t('makes.first_parts'), first_parts_path, class: 'btn btn-secondary' %>
-        <%= link_to t('makes.second_parts'), second_parts_path, class: 'btn btn-secondary' %>
+      <div class="flex flex-col sm:flex-row space-y-2 sm:space-y-0 sm:space-x-4">
+        <%= link_to t('makes.first_parts'), first_parts_path, class: 'btn btn-secondary w-full sm:w-auto' %>
+        <%= link_to t('makes.second_parts'), second_parts_path, class: 'btn btn-secondary w-full sm:w-auto' %>
       </div>
     </div>
 
     <br><br>
-    <% @makes.each do |make| %>
-      <div class="bg-base-100 shadow-xl w-auto my-2 mx-auto" style="width: 100%; max-width: 640px;">
-        <div class="card-body">
-          <h2 class="text-3xl font-semibold mb-2 text-center">
-            <div><%= make.first_part&.content || '' %></div>
-            <div><%= make.second_part&.content || '' %></div>
-          </h2>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <% @makes.each do |make| %>
+        <div class="bg-base-100 shadow-xl w-auto my-2 mx-auto" style="width: 100%; max-width: 640px;">
+          <div class="card-body">
+            <h2 class="text-3xl font-semibold mb-2 text-center">
+              <div><%= make.first_part&.content || '' %></div>
+              <div><%= make.second_part&.content || '' %></div>
+            </h2>
 
-          <div class="user-info flex items-center justify-center mt-4 space-x-4">
-            <% if make.first_part && make.second_part && make.first_part.user == make.second_part.user %>
-              <div class="avatar">
-                <div class="rounded-full w-10 h-10">
-                  <%= image_tag make.first_part.user.avatar.url, class: "rounded-full" %>
-                </div>
-              </div>
-              <span class="text-sm font-bold"><%= make.first_part.user.name %></span>
-            <% else %>
-              <% if make.first_part %>
+            <div class="user-info flex items-center justify-center mt-4 space-x-4">
+              <% if make.first_part && make.second_part && make.first_part.user == make.second_part.user %>
                 <div class="avatar">
                   <div class="rounded-full w-10 h-10">
                     <%= image_tag make.first_part.user.avatar.url, class: "rounded-full" %>
                   </div>
                 </div>
-                <span class="text-sm font-bold mr-4"><%= make.first_part.user.name %></span>
-              <% end %>
-              <% if make.second_part %>
-                <div class="avatar">
-                  <div class="rounded-full w-10 h-10">
-                    <%= image_tag make.second_part.user.avatar.url, class: "rounded-full" %>
+                <span class="text-sm font-bold"><%= make.first_part.user.name %></span>
+              <% else %>
+                <% if make.first_part %>
+                  <div class="avatar">
+                    <div class="rounded-full w-10 h-10">
+                      <%= image_tag make.first_part.user.avatar.url, class: "rounded-full" %>
+                    </div>
                   </div>
-                </div>
-                <span class="text-sm font-bold"><%= make.second_part.user.name %></span>
+                  <span class="text-sm font-bold mr-4"><%= make.first_part.user.name %></span>
+                <% end %>
+                <% if make.second_part %>
+                  <div class="avatar">
+                    <div class="rounded-full w-10 h-10">
+                      <%= image_tag make.second_part.user.avatar.url, class: "rounded-full" %>
+                    </div>
+                  </div>
+                  <span class="text-sm font-bold"><%= make.second_part.user.name %></span>
+                <% end %>
               <% end %>
-            <% end %>
-          </div>
+            </div>
 
-          <br>
-          <div class="mt-4 flex justify-center items-center space-x-4">
-            <% if user_signed_in? %>
-              <div class="flex space-x-4">
-                <% if make.first_part&.user == current_user || make.second_part&.user == current_user %>
-                  <%= link_to t('defaults.show'), make_path(make), class: 'btn btn-secondary' %>
-                <% end %>
-                <% if make.first_part.nil? %>
-                  <button class="btn btn-primary" onclick="document.getElementById('first_part_modal_<%= make.id %>').showModal()"><%= t('makes.add_first_part') %></button>
-                <% end %>
-                <% if make.second_part.nil? %>
-                  <button class="btn btn-primary" onclick="document.getElementById('second_part_modal_<%= make.id %>').showModal()"><%= t('makes.add_second_part') %></button>
-                <% end %>
-              </div>
-            <% end %>
-            <%= render 'shared/x_button2', { make: make } %>
-            <% if user_signed_in? %>
-              <div class="ml-auto">
-                <%= render 'like_buttons', { make: make } %>
-              </div>
-            <% end %>
+            <br>
+            <div class="mt-4 flex flex-col sm:flex-row justify-center items-center space-y-2 sm:space-y-0 sm:space-x-4">
+              <% if user_signed_in? %>
+                <div class="flex flex-col sm:flex-row space-y-2 sm:space-y-0 sm:space-x-4">
+                  <% if make.first_part&.user == current_user || make.second_part&.user == current_user %>
+                    <%= link_to t('defaults.show'), make_path(make), class: 'btn btn-secondary w-full sm:w-auto' %>
+                  <% end %>
+                  <% if make.first_part.nil? %>
+                    <button class="btn btn-primary w-full sm:w-auto" onclick="document.getElementById('first_part_modal_<%= make.id %>').showModal()"><%= t('makes.add_first_part') %></button>
+                  <% end %>
+                  <% if make.second_part.nil? %>
+                    <button class="btn btn-primary w-full sm:w-auto" onclick="document.getElementById('second_part_modal_<%= make.id %>').showModal()"><%= t('makes.add_second_part') %></button>
+                  <% end %>
+                </div>
+              <% end %>
+              <%= render 'shared/x_button2', { make: make } %>
+              <% if user_signed_in? %>
+                <div class="ml-auto">
+                  <%= render 'like_buttons', { make: make } %>
+                </div>
+              <% end %>
+            </div>
           </div>
         </div>
-      </div>
-      <%= render 'first_parts/modal', make: make %>
-      <%= render 'second_parts/modal', make: make %>
-    <% end %>
+        <%= render 'first_parts/modal', make: make %>
+        <%= render 'second_parts/modal', make: make %>
+      <% end %>
+    </div>
+    <%= paginate @makes%>
   </div>
 </div>
 

--- a/app/views/makes/show.html.erb
+++ b/app/views/makes/show.html.erb
@@ -1,5 +1,5 @@
 <br>
-<h1 class="text-3xl font-bold mb-4 text-center" style="color: #1E90FF;"><%= t('makes.new') %></h1>
+<h1 class="text-3xl font-bold mb-4 text-center" style="color: #00BFFF;"><%= t('makes.new') %></h1>
 <div class="flex justify-center items-center pt-8">
   <div class="w-2/3 text-center">
     <div class="card-body bg-base-100 shadow-xl p-8">
@@ -53,9 +53,9 @@
           <button class="btn btn-primary w-full mt-4" onclick="document.getElementById('second_part_modal_<%= @make.id %>').showModal()"><%= t('makes.add_second_part') %></button>
         <% end %>
         <br><br>
-        <%= link_to '作成された名言一覧に戻る', makes_path, class: 'btn btn-secondary w-full' %>
+        <%= link_to '作成された名言一覧に戻る', makes_path, class: 'btn btn-secondary w-full mt-4' %>
         <br><br>
-        <button class="btn btn-secondary w-full" onclick="document.getElementById('edit_modal_<%= @make.id %>').showModal()"><%= t('defaults.edit') %></button>
+        <button class="btn btn-secondary w-full mt-4" onclick="document.getElementById('edit_modal_<%= @make.id %>').showModal()"><%= t('defaults.edit') %></button>
         <br><br>
         <% if @make.first_part && @make.second_part %>
           <%= render 'shared/x_button2', { make: @make } %>

--- a/app/views/second_parts/index.html.erb
+++ b/app/views/second_parts/index.html.erb
@@ -29,6 +29,7 @@
               <button class="btn btn-primary" onclick="document.getElementById('first_part_modal_<%= second_part.make.id %>').showModal()"><%= t('makes.add_first_part') %></button>
             <% end %>
           </div>
+          <%= paginate @second_parts%>
         </div>
       </div>
       <!-- モーダルをレンダリング -->

--- a/app/views/shared/_x_button2.html.erb
+++ b/app/views/shared/_x_button2.html.erb
@@ -1,3 +1,4 @@
+<!-- shared/_x_button2.html.erb -->
 <% if make.first_part && make.second_part %>
   <% quote = "#{make.first_part.content} #{make.second_part.content}" %>
   <% encoded_quote = ERB::Util.url_encode("名言の海を探索したら、こんな言葉を見つけたよ！\n\n#{quote}") %>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 20
+  # config.max_per_page = nil
+  config.window = 10
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end


### PR DESCRIPTION
# 概要
みんなの作成した名言一覧ページの改善
## 実装内容、確認ポイント
- **デスクトップサイズでの表示の場合、名言が２列で表示されるように実装**
- **gemのkaminariを使ったページネーションの導入**
- [x] gemの追加
- [x] `config/initializers/kaminari_config.rb`の作成と修正
- [x] `bin/rails g kaminari:views default`コマンドの実行と、生成されたファイルをTailwindCSS用に修正
- [x] makes/indexの修正
- [x] makesコントローラの修正
- [x] first_parts/indexの修正
- [x] first_partsコントローラの修正
- [x] second_parts/indexの修正
- [x] second_partsコントローラの修正

<img width="1464" alt="スクリーンショット 2024-06-05 17 10 10" src="https://github.com/daichi3102/wordpass/assets/149915927/6695fb13-28a3-420c-9dbc-8168e94689ea">

実装ログ [Notion](https://www.notion.so/268d008607e7433b915990e156ed4f0e?showMoveTo=true&saveParent=true)
closes #120 