### PR TITLE
AIからの名言取得機能にも検索機能を導入

### DIFF
--- a/app/controllers/fetch_ais_controller.rb
+++ b/app/controllers/fetch_ais_controller.rb
@@ -5,7 +5,8 @@ class FetchAisController < ApplicationController
   before_action :set_fetch_ai, only: %i[show edit update destroy]
 
   def index
-    @fetch_ais = FetchAi.order(created_at: :desc).page(params[:page])
+    @q = FetchAi.ransack(params[:q])
+    @fetch_ais = @q.result(distinct: true).order(created_at: :desc).page(params[:page])
     @fetch_ai = FetchAi.new
   end
 

--- a/app/models/fetch_ai.rb
+++ b/app/models/fetch_ai.rb
@@ -7,7 +7,7 @@ class FetchAi < ApplicationRecord
   belongs_to :user, optional: true
 
   # Ransackで使用するスコープを追加
-  def self.ransackable_attributes(auth_object = nil)
-    ["created_at", "how", "id", "mood", "popularity", "quote_type", "response", "schedule", "updated_at", "user_id"]
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[created_at how id mood popularity quote_type response schedule updated_at user_id]
   end
 end

--- a/app/models/fetch_ai.rb
+++ b/app/models/fetch_ai.rb
@@ -5,4 +5,9 @@ class FetchAi < ApplicationRecord
 
   # optional: true を追加してユーザーの関連付けをオプショナルにする
   belongs_to :user, optional: true
+
+  # Ransackで使用するスコープを追加
+  def self.ransackable_attributes(auth_object = nil)
+    ["created_at", "how", "id", "mood", "popularity", "quote_type", "response", "schedule", "updated_at", "user_id"]
+  end
 end

--- a/app/views/fetch_ais/_search_form.html.erb
+++ b/app/views/fetch_ais/_search_form.html.erb
@@ -1,0 +1,18 @@
+<!-- app/views/fetch_ais/_search_form.html.erb -->
+<%= search_form_for @q, url: fetch_ais_path, method: :get, html: {class: 'form-inline flex flex-wrap justify-center gap-4'} do |f| %>
+  <div class="mb-3 text-center">
+    <%= f.label :mood_eq, "Mood", class: "form-label block mb-2 text-sm font-bold" %>
+    <%= f.select :mood_eq, options_for_select([["選ばない", nil], "普通", "楽しい", "元気", "落ち気味", "悲しい", "イライラ"], params.dig(:q, :mood_eq)), {}, {class: "select select-bordered select-primary w-full max-w-xs"} %>
+  </div>
+  <div class="mb-3 text-center">
+    <%= f.label :quote_type_eq, "Quote Type", class: "form-label block mb-2 text-sm font-bold" %>
+    <%= f.select :quote_type_eq, options_for_select([["選ばない", nil], "漫画", "映画", "アニメ", "書籍", "偉人", "有名人"], params.dig(:q, :quote_type_eq)), {}, {class: "select select-bordered select-primary w-full max-w-xs"} %>
+  </div>
+  <div class="mb-3 text-center">
+    <%= f.label :response_cont, "Freeword", class: "form-label block mb-2 text-sm font-bold" %>
+    <%= f.text_field :response_cont, value: params.dig(:q, :response_cont), class: "input input-bordered input-primary w-full max-w-xs"%>
+  </div>
+  <div class="mb-3 text-center self-end">
+    <%= f.submit t('defaults.search'), class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/app/views/fetch_ais/index.html.erb
+++ b/app/views/fetch_ais/index.html.erb
@@ -8,7 +8,10 @@
       <div data-controller="loading"> 
       <%= render 'shared/ai_button', fetch_ai: @fetch_ai %>
       </div>
-      <br><br>
+      <br>
+
+      <%= render 'search_form', q: @q, url: fetch_ais_path %> 
+      <br>
 
       <div class="card-body">
         <% @fetch_ais.each do |fetch_ai| %>

--- a/app/views/fetch_ais/new.html.erb
+++ b/app/views/fetch_ais/new.html.erb
@@ -1,33 +1,27 @@
 <!-- app/views/fetch_ais/new.html.erb -->
 <br>
 <h1 class="text-3xl font-bold mb-4 text-center" style="color: #00BFFF;"><%= t('fetch_ais.new') %></h1>
-<div class="flex justify-center items-center pt-8">
-  <div class="w-2/3 text-center">
-    <div class="flex flex-col items-center space-y-4 mb-4">
-      <small class="text-gray-500 text-center mb-4">
-      時間のない時にはすぐに受け取るボタン！<br>
-      少しでもあれば、条件を指定して受け取ろう！<br><br>
-      偉人、有名人、書籍、映画、漫画、アニメ<br>
-      メジャー or マイナーな作品など<br>
-      全５項目から自分で条件を選択しよう！
-
-        <div class="flex justify-center item-center pt-8">
-          <figure class="w-full sm:w-72">
-            <img src="/MOai.gif" alt="GIF Image" class="rounded-xl w-full h-72 object-cover" />
-          </figure>
-        </div>
-        <br>
-
-        <div data-controller="loading"> 
+<div class="relative flex justify-center items-center pt-8">
+  <div class="card card-side bg-base-100 shadow-xl w-full max-w-3xl mx-auto flex flex-col lg:flex-row">
+    <figure class="w-full lg:w-1/2">
+      <img src="/MOai.gif" alt="GIF Image" class="rounded-xl w-full h-full object-cover" style="object-fit: contain;" />
+    </figure>
+    <div class="card-body flex flex-col items-center justify-center text-center sm:justify-center">
+      <small class="text-center text-gray-500 mb-4">
+        時間のない時にはすぐに受け取るボタン！<br>
+        少しでもあれば、条件を指定して受け取ろう！<br><br>
+        偉人、有名人、書籍、映画、漫画、アニメ<br>
+        メジャー or マイナーな作品など<br>
+        全５項目から自分で条件を選択しよう！
+      </small>
+      <div data-controller="loading" class="w-full text-center sm:justify-center">
         <%= render 'shared/ai_button', fetch_ai: @fetch_ai %>
+      </div>
+      <% if user_signed_in? %>
+        <div class="card-actions justify-center sm:justify-center mt-4">
+          <%= link_to t('fetch_ais.index'), fetch_ais_path, class: "btn btn-secondary" %>
         </div>
-        <br><br>
-
-        <div class="mb-8">
-          <% if user_signed_in? %>
-            <%= link_to t('fetch_ais.index'), fetch_ais_path, class: "btn btn-secondary mt-4" %>
-          <% end %>
-        </div>
-        <br><br>
+      <% end %>
     </div>
   </div>
+</div>

--- a/app/views/makes/new.html.erb
+++ b/app/views/makes/new.html.erb
@@ -1,36 +1,35 @@
 <!-- app/views/makes/new.html.erb -->
 <br>
 <h1 class="text-3xl font-bold mb-4 text-center" style="color: #00BFFF;"><%= t('makes.new') %></h1>
-<div class="flex justify-center items-center pt-8">
-  <div class="w-2/3 text-center">
-    <div class="flex flex-col items-center space-y-4 mb-4">
-
-      <small class="text-gray-500">※上の句のみ、下の句のみ、両方、どれでも投稿できるよ！
-        <br>※ひとりで投稿する場合は、両方使って投稿しよう!
+<div class="relative flex justify-center items-center pt-8">
+  <div class="card card-side bg-base-100 shadow-xl w-full max-w-3xl mx-auto flex flex-col lg:flex-row">
+    <figure class="w-full lg:w-1/2">
+      <img src="/MOmake.gif" alt="GIF Image" class="rounded-xl w-full h-full object-cover" style="object-fit: contain;" />
+    </figure>
+    <div class="card-body flex flex-col items-center justify-center text-center sm:justify-center">
+      <small class="text-center text-gray-500 mb-4">
+        ※上の句か下の句のみ、両方、どれでも投稿できるよ！
         <br>
-
-        <div class="flex justify-center item-center pt-8">
-          <figure class="w-full sm:w-72">
-            <img src="/MOmake.gif" alt="GIF Image" class="rounded-xl w-full h-72 object-cover" />
-          </figure>
-        </div>
+        ※ひとりで投稿する場合は、両方使って投稿しよう!
         <br><br>
-
-        <div class="flex flex-col items-center space-y-4 mb-4">
-          <button class="btn btn-primary" onclick="document.getElementById('make_modal').showModal()"><%= t('makes.new') %></button>
-          <br>
-          <div class="flex space-x-4">
-            <%= link_to t('makes.first_parts'), first_parts_path, class: 'btn btn-secondary' %>
-            <%= link_to t('makes.second_parts'), second_parts_path, class: 'btn btn-secondary' %>
-          </div>
+        ※自分の好きな名言、格言、言葉、座右の銘、なんでも投稿してね！
+        <br><br>
+      </small>
+      <div class="w-full text-center sm:justify-center">
+        <button class="btn btn-primary" onclick="document.getElementById('make_modal').showModal()"><%= t('makes.new') %></button>
+      </div>
+      <br>
+      <div class="card-actions justify-center sm:justify-center mt-4">
+        <div class="flex space-x-4">
+          <%= link_to t('makes.first_parts'), first_parts_path, class: 'btn btn-secondary' %>
+          <%= link_to t('makes.second_parts'), second_parts_path, class: 'btn btn-secondary' %>
         </div>
+      </div>
+      <br>
+      <div class="card-actions justify-center sm:justify-center mt-4">
+        <%= link_to t('makes.back'), makes_path, class: 'btn btn-secondary' %>
+      </div>
     </div>
-    <br>
-
-    <div class="mt-4">
-      <%= link_to t('makes.back'), makes_path, class: 'btn btn-secondary' %>
-    </div>
-    <br><br><br><br>
   </div>
 </div>
 

--- a/app/views/shared/_ai_button.html.erb
+++ b/app/views/shared/_ai_button.html.erb
@@ -21,23 +21,23 @@
         <%= form.hidden_field :prompt_type, value: 'personalized' %>
         <div class="mb-3 text-center">
           <%= form.label :mood, class: "form-label block mb-2 text-sm font-bold" %>
-          <%= form.select :mood, options_for_select(["普通", "楽しい", "元気", "落ち気味", "悲しい", "イライラ"], @fetch_ai.mood), {}, {class: "select select-bordered w-full max-w-xs"} %>
+          <%= form.select :mood, options_for_select(["普通", "楽しい", "元気", "落ち気味", "悲しい", "イライラ"], @fetch_ai.mood), {}, {class: "select select-bordered select-primary w-full max-w-xs"} %>
         </div>
         <div class="mb-3 text-center">
           <%= form.label :schedule, class: "form-label block mb-2 text-sm font-bold" %>
-          <%= form.select :schedule, options_for_select(["仕事", "学習", "健康の事", "家庭の事", "趣味", "自己に関わること"], @fetch_ai.schedule), {}, {class: "select select-bordered w-full max-w-xs"} %>
+          <%= form.select :schedule, options_for_select(["仕事", "学習", "健康の事", "家庭の事", "趣味", "自己に関わること"], @fetch_ai.schedule), {}, {class: "select select-bordered select-primary w-full max-w-xs"} %>
         </div>
         <div class="mb-3 text-center">
           <%= form.label :how, class: "form-label block mb-2 text-sm font-bold" %>
-          <%= form.select :how, options_for_select(["心に刺さる名言", "心に寄り添う名言", "クスっと笑ってしまう名言", "厳しい名言", "恋愛に関する名言", "人生に関する名言"], @fetch_ai.how), {}, {class: "select select-bordered w-full max-w-xs"} %>
+          <%= form.select :how, options_for_select(["心に刺さる名言", "心に寄り添う名言", "クスっと笑ってしまう名言", "厳しい名言", "恋愛に関する名言", "人生に関する名言"], @fetch_ai.how), {}, {class: "select select-bordered select-primary w-full max-w-xs"} %>
         </div>
         <div class="mb-3 text-center">
           <%= form.label :popularity, class: "form-label block mb-2 text-sm font-bold" %>
-          <%= form.select :popularity, options_for_select(["メジャーな", "マイナーな", "メジャーでもマイナーでもないような"], @fetch_ai.popularity), {}, {class: "select select-bordered w-full max-w-xs"} %>
+          <%= form.select :popularity, options_for_select(["メジャーな", "マイナーな", "メジャーでもマイナーでもないような"], @fetch_ai.popularity), {}, {class: "select select-bordered select-primary w-full max-w-xs"} %>
         </div>
         <div class="mb-3 text-center">
           <%= form.label :quote_type, class: "form-label block mb-2 text-sm font-bold" %>
-          <%= form.select :quote_type, options_for_select(["漫画", "映画", "アニメ", "書籍", "偉人", "有名人"], @fetch_ai.quote_type), {}, {class: "select select-bordered w-full max-w-xs"} %>
+          <%= form.select :quote_type, options_for_select(["漫画", "映画", "アニメ", "書籍", "偉人", "有名人"], @fetch_ai.quote_type), {}, {class: "select select-bordered select-primary w-full max-w-xs"} %>
         </div>
         <div class="modal-action justify-center" data-loading-target="customsubmit">
           <%= form.submit t('fetch_ais.getter'), class: "btn btn-primary mt-4 w-full max-w-xs" %>

--- a/app/views/tops/index.html.erb
+++ b/app/views/tops/index.html.erb
@@ -7,6 +7,7 @@
   <div class="relative flex flex-col justify-center items-center min-h-screen pt-8 z-10 text-center">
     <h1 class="text-5xl font-bold mb-4 text-center" style="color: #00BFFF;"><%= t('tops.subtitle') %></h1>
     <br><br>
+
     <p class="mb-4">らっこがAIの力を借りて、名言の海から言葉を提供するよ？<br><br>  
     偉人、有名人、書籍、映画、漫画、アニメなど<br>
     様々な作品からの名言や格言を受け取ろう！<br><br>
@@ -20,6 +21,7 @@
 
     <h2 class="text-2xl font-bold mb-4 text-center" style="color: #00BFFF;">名言おった?</h2>
     <br>
+
     <figure class="mb-8" style="width: 300px; height: 300px;">
       <img src="/MOtop.gif" alt="GIF Image" class="rounded-xl w-full h-full object-cover" />
     </figure>

--- a/app/views/tops/index.html.erb
+++ b/app/views/tops/index.html.erb
@@ -5,20 +5,18 @@
   </figure>
 
   <div class="relative flex flex-col justify-center items-center min-h-screen pt-8 z-10 text-center">
-    <br>
     <h1 class="text-5xl font-bold mb-4 text-center" style="color: #00BFFF;"><%= t('tops.subtitle') %></h1>
-    <br><br><br>
-    <p class="mb-4">らっこがAIの力を借りて、名言の海から言葉を提供するよ？<br><br><br><br>
+    <br><br>
+    <p class="mb-4">らっこがAIの力を借りて、名言の海から言葉を提供するよ？<br><br>  
     偉人、有名人、書籍、映画、漫画、アニメなど<br>
     様々な作品からの名言や格言を受け取ろう！<br><br>
     日々の生活に欠かせない言葉を通じて<br>
     心のエネルギーを補給しよう！
     </p>
-    <br>
     <div data-controller="loading"> 
     <%= render 'shared/ai_button', fetch_ai: @fetch_ai %>
     </div>
-    <br><br><br><br>
+    <br><br><br>
 
     <h2 class="text-2xl font-bold mb-4 text-center" style="color: #00BFFF;">名言おった?</h2>
     <br>
@@ -32,7 +30,9 @@
       <br><br>
 
       <div class="card card-side bg-base-100 shadow-xl mb-8 w-full max-w-3xl mx-auto flex flex-col sm:flex-row">
-        <figure class="w-full sm:w-72"><img src="/MOai.gif" alt="GIF Image" class="rounded-xl w-full h-72 object-cover" /></figure>
+        <figure class="w-full sm:w-72">
+          <img src="/MOai.gif" alt="GIF Image" class="rounded-xl w-full h-72 object-cover" />
+        </figure>
         <div class="card-body flex flex-col items-center justify-center text-center sm:justify-center">
           <h2 class="card-title text-2xl font-bold text-center mb-4" style="color: #00BFFF;">AIから自分に合った名言がもらえる！</h2>
           <p class="text-center mb-4">時間のない時にはすぐに受け取るボタン！<br>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,90 +10,90 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 20_240_518_163_012) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_18_163012) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+  enable_extension "plpgsql"
 
-  create_table 'fetch_ais', force: :cascade do |t|
-    t.string 'mood'
-    t.string 'schedule'
-    t.string 'how'
-    t.string 'popularity'
-    t.string 'quote_type'
-    t.text 'response'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.bigint 'user_id'
-    t.index ['user_id'], name: 'index_fetch_ais_on_user_id'
+  create_table "fetch_ais", force: :cascade do |t|
+    t.string "mood"
+    t.string "schedule"
+    t.string "how"
+    t.string "popularity"
+    t.string "quote_type"
+    t.text "response"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_fetch_ais_on_user_id"
   end
 
-  create_table 'first_parts', force: :cascade do |t|
-    t.text 'content'
-    t.bigint 'user_id', null: false
-    t.bigint 'make_id', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['make_id'], name: 'index_first_parts_on_make_id'
-    t.index ['user_id'], name: 'index_first_parts_on_user_id'
+  create_table "first_parts", force: :cascade do |t|
+    t.text "content"
+    t.bigint "user_id", null: false
+    t.bigint "make_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["make_id"], name: "index_first_parts_on_make_id"
+    t.index ["user_id"], name: "index_first_parts_on_user_id"
   end
 
-  create_table 'likes', force: :cascade do |t|
-    t.bigint 'user_id'
-    t.bigint 'make_id'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['make_id'], name: 'index_likes_on_make_id'
-    t.index %w[user_id make_id], name: 'index_likes_on_user_id_and_make_id', unique: true
-    t.index ['user_id'], name: 'index_likes_on_user_id'
+  create_table "likes", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "make_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["make_id"], name: "index_likes_on_make_id"
+    t.index ["user_id", "make_id"], name: "index_likes_on_user_id_and_make_id", unique: true
+    t.index ["user_id"], name: "index_likes_on_user_id"
   end
 
-  create_table 'makes', force: :cascade do |t|
-    t.bigint 'user_id', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['user_id'], name: 'index_makes_on_user_id'
+  create_table "makes", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_makes_on_user_id"
   end
 
-  create_table 'second_parts', force: :cascade do |t|
-    t.text 'content'
-    t.bigint 'user_id', null: false
-    t.bigint 'make_id', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['make_id'], name: 'index_second_parts_on_make_id'
-    t.index ['user_id'], name: 'index_second_parts_on_user_id'
+  create_table "second_parts", force: :cascade do |t|
+    t.text "content"
+    t.bigint "user_id", null: false
+    t.bigint "make_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["make_id"], name: "index_second_parts_on_make_id"
+    t.index ["user_id"], name: "index_second_parts_on_user_id"
   end
 
-  create_table 'sns_credentials', force: :cascade do |t|
-    t.string 'provider'
-    t.string 'uid'
-    t.bigint 'user_id'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['user_id'], name: 'index_sns_credentials_on_user_id'
+  create_table "sns_credentials", force: :cascade do |t|
+    t.string "provider"
+    t.string "uid"
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_sns_credentials_on_user_id"
   end
 
-  create_table 'users', force: :cascade do |t|
-    t.string 'email', default: '', null: false
-    t.string 'encrypted_password', default: '', null: false
-    t.string 'name'
-    t.string 'reset_password_token'
-    t.datetime 'reset_password_sent_at'
-    t.datetime 'remember_created_at'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.string 'avatar'
-    t.index ['email'], name: 'index_users_on_email', unique: true
-    t.index ['reset_password_token'], name: 'index_users_on_reset_password_token', unique: true
+  create_table "users", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "name"
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "avatar"
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  add_foreign_key 'fetch_ais', 'users'
-  add_foreign_key 'first_parts', 'makes'
-  add_foreign_key 'first_parts', 'users'
-  add_foreign_key 'likes', 'makes'
-  add_foreign_key 'likes', 'users'
-  add_foreign_key 'makes', 'users'
-  add_foreign_key 'second_parts', 'makes'
-  add_foreign_key 'second_parts', 'users'
-  add_foreign_key 'sns_credentials', 'users'
+  add_foreign_key "fetch_ais", "users"
+  add_foreign_key "first_parts", "makes"
+  add_foreign_key "first_parts", "users"
+  add_foreign_key "likes", "makes"
+  add_foreign_key "likes", "users"
+  add_foreign_key "makes", "users"
+  add_foreign_key "second_parts", "makes"
+  add_foreign_key "second_parts", "users"
+  add_foreign_key "sns_credentials", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -10,90 +12,90 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_18_163012) do
+ActiveRecord::Schema[7.1].define(version: 20_240_518_163_012) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension 'plpgsql'
 
-  create_table "fetch_ais", force: :cascade do |t|
-    t.string "mood"
-    t.string "schedule"
-    t.string "how"
-    t.string "popularity"
-    t.string "quote_type"
-    t.text "response"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.bigint "user_id"
-    t.index ["user_id"], name: "index_fetch_ais_on_user_id"
+  create_table 'fetch_ais', force: :cascade do |t|
+    t.string 'mood'
+    t.string 'schedule'
+    t.string 'how'
+    t.string 'popularity'
+    t.string 'quote_type'
+    t.text 'response'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.bigint 'user_id'
+    t.index ['user_id'], name: 'index_fetch_ais_on_user_id'
   end
 
-  create_table "first_parts", force: :cascade do |t|
-    t.text "content"
-    t.bigint "user_id", null: false
-    t.bigint "make_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["make_id"], name: "index_first_parts_on_make_id"
-    t.index ["user_id"], name: "index_first_parts_on_user_id"
+  create_table 'first_parts', force: :cascade do |t|
+    t.text 'content'
+    t.bigint 'user_id', null: false
+    t.bigint 'make_id', null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['make_id'], name: 'index_first_parts_on_make_id'
+    t.index ['user_id'], name: 'index_first_parts_on_user_id'
   end
 
-  create_table "likes", force: :cascade do |t|
-    t.bigint "user_id"
-    t.bigint "make_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["make_id"], name: "index_likes_on_make_id"
-    t.index ["user_id", "make_id"], name: "index_likes_on_user_id_and_make_id", unique: true
-    t.index ["user_id"], name: "index_likes_on_user_id"
+  create_table 'likes', force: :cascade do |t|
+    t.bigint 'user_id'
+    t.bigint 'make_id'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['make_id'], name: 'index_likes_on_make_id'
+    t.index %w[user_id make_id], name: 'index_likes_on_user_id_and_make_id', unique: true
+    t.index ['user_id'], name: 'index_likes_on_user_id'
   end
 
-  create_table "makes", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_makes_on_user_id"
+  create_table 'makes', force: :cascade do |t|
+    t.bigint 'user_id', null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['user_id'], name: 'index_makes_on_user_id'
   end
 
-  create_table "second_parts", force: :cascade do |t|
-    t.text "content"
-    t.bigint "user_id", null: false
-    t.bigint "make_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["make_id"], name: "index_second_parts_on_make_id"
-    t.index ["user_id"], name: "index_second_parts_on_user_id"
+  create_table 'second_parts', force: :cascade do |t|
+    t.text 'content'
+    t.bigint 'user_id', null: false
+    t.bigint 'make_id', null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['make_id'], name: 'index_second_parts_on_make_id'
+    t.index ['user_id'], name: 'index_second_parts_on_user_id'
   end
 
-  create_table "sns_credentials", force: :cascade do |t|
-    t.string "provider"
-    t.string "uid"
-    t.bigint "user_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_sns_credentials_on_user_id"
+  create_table 'sns_credentials', force: :cascade do |t|
+    t.string 'provider'
+    t.string 'uid'
+    t.bigint 'user_id'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['user_id'], name: 'index_sns_credentials_on_user_id'
   end
 
-  create_table "users", force: :cascade do |t|
-    t.string "email", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.string "name"
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "avatar"
-    t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  create_table 'users', force: :cascade do |t|
+    t.string 'email', default: '', null: false
+    t.string 'encrypted_password', default: '', null: false
+    t.string 'name'
+    t.string 'reset_password_token'
+    t.datetime 'reset_password_sent_at'
+    t.datetime 'remember_created_at'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.string 'avatar'
+    t.index ['email'], name: 'index_users_on_email', unique: true
+    t.index ['reset_password_token'], name: 'index_users_on_reset_password_token', unique: true
   end
 
-  add_foreign_key "fetch_ais", "users"
-  add_foreign_key "first_parts", "makes"
-  add_foreign_key "first_parts", "users"
-  add_foreign_key "likes", "makes"
-  add_foreign_key "likes", "users"
-  add_foreign_key "makes", "users"
-  add_foreign_key "second_parts", "makes"
-  add_foreign_key "second_parts", "users"
-  add_foreign_key "sns_credentials", "users"
+  add_foreign_key 'fetch_ais', 'users'
+  add_foreign_key 'first_parts', 'makes'
+  add_foreign_key 'first_parts', 'users'
+  add_foreign_key 'likes', 'makes'
+  add_foreign_key 'likes', 'users'
+  add_foreign_key 'makes', 'users'
+  add_foreign_key 'second_parts', 'makes'
+  add_foreign_key 'second_parts', 'users'
+  add_foreign_key 'sns_credentials', 'users'
 end


### PR DESCRIPTION
# 概要
AIからの名言取得機能にも検索機能を導入
## 実装内容
- [x] fetch_aisコントローラのindexアクションを修正
- [x] fetch_aiモデルに検索の定義を追記
- [x] パーシャルで検索フォームを作成
- [x] fetch_aisのnewページの改装（レスポンシブデザイン）
- [x] makesのnewページの改装（レスポンシブデザイン）
- [x] tops/indexの修正
- [x] その他微調整
## 確認ポイント
- [x] quote_typeとmoodカラムからプルダウンで検索ができる
- [x] responseカラムからフリーワードで検索ができる
- [x] それぞれを全て選ばなくても検索が可能

![7b4403659af7bdb82213c91ce3620f8d](https://github.com/daichi3102/wordpass/assets/149915927/72b0815e-899b-4ea7-9041-8bb98ba1925e)
レスポンシブデザイン
![54e7a2791c516e303a9c906f7091f4d8](https://github.com/daichi3102/wordpass/assets/149915927/700b279f-178f-4de9-915d-8858c0eaada6)

実装ログ [Notion](https://www.notion.so/AI-849be2157d1948fc84d7849e044fa6f1)
closes #141 